### PR TITLE
feat(controller): redesigned layout with audio panel, macro bar, DSK, tally view

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,8 +2,14 @@ import { createBrowserRouter, Navigate } from 'react-router'
 import { Shell } from '@/components/layout/Shell'
 import { SetupPage } from '@/pages/SetupPage'
 import { ControllerPage } from '@/pages/ControllerPage'
+import { TallyPage } from '@/pages/TallyPage'
 
 export const router = createBrowserRouter([
+  {
+    // Tally page is standalone — no Shell wrapper, no auth required
+    path: '/tally',
+    element: <TallyPage />,
+  },
   {
     path: '/',
     element: <Shell />,

--- a/src/hooks/useControllerWs.ts
+++ b/src/hooks/useControllerWs.ts
@@ -1,0 +1,75 @@
+import { useEffect, useCallback, useRef } from 'react'
+import { useProductionStore } from '@/store/production.store'
+
+const WS_BASE = (import.meta.env.VITE_API_URL ?? 'http://localhost:3000')
+  .replace(/^http/, 'ws')
+
+type OutboundMessage =
+  | { type: 'CUT'; sourceId: string }
+  | { type: 'TRANSITION'; sourceId: string; transitionType: string; durationMs?: number }
+  | { type: 'TAKE' }
+  | { type: 'GO_LIVE' }
+  | { type: 'CUT_STREAM' }
+  | { type: 'GRAPHIC_ON'; overlayId: string }
+  | { type: 'GRAPHIC_OFF'; overlayId: string }
+  | { type: 'DSK_TOGGLE'; layer: number; visible?: boolean }
+  | { type: 'MACRO_EXEC'; macroId: string }
+
+/**
+ * Opens a WebSocket connection to /ws/productions/:id/controller.
+ * Syncs server-side tally state into the production store.
+ * Returns a stable `send` function for dispatching controller messages.
+ */
+export function useControllerWs(productionId: string | null): (msg: OutboundMessage) => void {
+  const wsRef = useRef<WebSocket | null>(null)
+  const setPgm = useProductionStore((s) => s.setPgm)
+  const setPvw = useProductionStore((s) => s.setPvw)
+  const setLive = useProductionStore((s) => s.setLive)
+
+  useEffect(() => {
+    if (!productionId) return
+
+    const ws = new WebSocket(`${WS_BASE}/ws/productions/${productionId}/controller`)
+    wsRef.current = ws
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data as string) as Record<string, unknown>
+        switch (msg['type']) {
+          case 'TALLY':
+            if (typeof msg['pgm'] === 'string' || msg['pgm'] === null) {
+              setPgm(msg['pgm'] as string)
+            }
+            if (typeof msg['pvw'] === 'string' || msg['pvw'] === null) {
+              setPvw(msg['pvw'] as string)
+            }
+            break
+          case 'ON_AIR':
+            setLive(!!msg['value'])
+            break
+          // DSK_STATE, MACRO_EXECUTED, MACRO_ERROR — handled by consumers if needed
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    }
+
+    ws.onerror = () => {
+      // Connection errors are silent — the controller degrades gracefully
+    }
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [productionId, setPgm, setPvw, setLive])
+
+  const send = useCallback((msg: OutboundMessage) => {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg))
+    }
+  }, [])
+
+  return send
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -137,6 +137,78 @@ export const sourcesApi = {
     request<void>(`/api/v1/sources/${id}`, { method: 'DELETE' }),
 }
 
+// --------------- Macro types ---------------
+
+export interface ApiMacroAction {
+  type: 'CUT' | 'TRANSITION' | 'TAKE' | 'GRAPHIC_ON' | 'GRAPHIC_OFF' | 'DSK_TOGGLE'
+  sourceId?: string
+  transitionType?: string
+  durationMs?: number
+  overlayId?: string
+  layer?: number
+  visible?: boolean
+}
+
+export interface ApiMacro {
+  id: string
+  slot: number
+  label: string
+  color: string
+  actions: ApiMacroAction[]
+}
+
+export interface ApiAudioElement {
+  id: string
+  blockId: string
+  elementId: string
+  label: string
+}
+
+export interface ApiStreamingStats {
+  active: boolean
+  rtpStats?: unknown
+  webrtcStats?: unknown
+  error?: string
+}
+
+export const macrosApi = {
+  list: (productionId: string) =>
+    request<ApiMacro[]>(`/api/v1/productions/${productionId}/macros`),
+
+  create: (productionId: string, body: Omit<ApiMacro, 'id'>) =>
+    request<ApiMacro>(`/api/v1/productions/${productionId}/macros`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  update: (productionId: string, macroId: string, body: Partial<Omit<ApiMacro, 'id'>>) =>
+    request<ApiMacro>(`/api/v1/productions/${productionId}/macros/${macroId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+
+  remove: (productionId: string, macroId: string) =>
+    request<void>(`/api/v1/productions/${productionId}/macros/${macroId}`, { method: 'DELETE' }),
+}
+
+export const audioApi = {
+  getElement: (productionId: string, elementId: string) =>
+    request<{ element_id: string; properties: Record<string, unknown> }>(
+      `/api/v1/productions/${productionId}/audio/${elementId}`,
+    ),
+
+  updateElement: (productionId: string, elementId: string, body: { property: string; value: unknown }) =>
+    request<{ element_id: string; properties: Record<string, unknown> }>(
+      `/api/v1/productions/${productionId}/audio/${elementId}`,
+      { method: 'PATCH', body: JSON.stringify(body) },
+    ),
+}
+
+export const statsApi = {
+  streaming: (productionId: string) =>
+    request<ApiStreamingStats>(`/api/v1/productions/${productionId}/stats/streaming`),
+}
+
 export const templatesApi = {
   list: () =>
     request<ApiTemplate[]>('/api/v1/templates'),

--- a/src/pages/ControllerPage/AudioPanel.tsx
+++ b/src/pages/ControllerPage/AudioPanel.tsx
@@ -1,0 +1,77 @@
+import { useAudioStore } from '@/store/audio.store'
+import { cn } from '@/lib/cn'
+
+function Fader({ elementId, label }: { elementId: string; label: string }) {
+  const level = useAudioStore((s) => s.levels[elementId] ?? 1.0)
+  const muted = useAudioStore((s) => s.muted[elementId] ?? false)
+  const setLevel = useAudioStore((s) => s.setLevel)
+  const toggleMute = useAudioStore((s) => s.toggleMute)
+
+  return (
+    <div className="flex flex-col items-center gap-1 min-w-[44px]">
+      {/* VU meter */}
+      <div className="relative w-3 h-20 bg-zinc-800 rounded overflow-hidden">
+        <div
+          className={cn(
+            'absolute bottom-0 w-full rounded transition-none',
+            muted ? 'bg-zinc-600' : level > 0.9 ? 'bg-red-500' : level > 0.7 ? 'bg-yellow-500' : 'bg-green-500',
+          )}
+          style={{ height: `${level * 100}%` }}
+        />
+      </div>
+      {/* Fader */}
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={level}
+        onChange={(e) => setLevel(elementId, parseFloat(e.target.value))}
+        disabled={muted}
+        className="w-20 cursor-pointer"
+        style={{ writingMode: 'vertical-lr', direction: 'rtl', height: '80px' }}
+        aria-label={`${label} level`}
+      />
+      {/* Mute */}
+      <button
+        onClick={() => toggleMute(elementId)}
+        className={cn(
+          'text-[9px] font-bold uppercase w-8 py-0.5 rounded border transition-colors',
+          muted
+            ? 'bg-red-600 text-white border-red-600'
+            : 'bg-[--color-surface-raised] text-[--color-text-muted] border-[--color-border]',
+        )}
+        aria-label={muted ? `Unmute ${label}` : `Mute ${label}`}
+      >
+        M
+      </button>
+      <span className="text-[9px] text-[--color-text-muted] text-center max-w-[44px] truncate">{label}</span>
+    </div>
+  )
+}
+
+export function AudioPanel() {
+  const elements = useAudioStore((s) => s.elements)
+
+  if (elements.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 p-3 bg-[--color-surface-3] rounded-xl border border-[--color-border] min-h-[120px] items-center justify-center">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-[--color-text-muted]">Audio</span>
+        <p className="text-[10px] text-[--color-text-muted] text-center">
+          No audio elements defined in template
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
+      <span className="text-[10px] font-bold uppercase tracking-widest text-[--color-text-muted]">Audio</span>
+      <div className="flex gap-3 overflow-x-auto">
+        {elements.map((el) => (
+          <Fader key={el.elementId} elementId={el.elementId} label={el.label} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ControllerPage/DskPanel.tsx
+++ b/src/pages/ControllerPage/DskPanel.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+
+interface DskPanelProps {
+  onToggle: (layer: number, visible: boolean) => void
+}
+
+export function DskPanel({ onToggle }: DskPanelProps) {
+  const [dsk1, setDsk1] = useState(false)
+  const [dsk2, setDsk2] = useState(false)
+
+  const toggle = (layer: number) => {
+    if (layer === 0) {
+      const next = !dsk1
+      setDsk1(next)
+      onToggle(0, next)
+    } else {
+      const next = !dsk2
+      setDsk2(next)
+      onToggle(1, next)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
+      <span className="text-[10px] font-bold uppercase tracking-widest text-[--color-text-muted]">DSK</span>
+      <div className="flex gap-2">
+        {[{ label: 'DSK 1', active: dsk1, layer: 0 }, { label: 'DSK 2', active: dsk2, layer: 1 }].map(({ label, active, layer }) => (
+          <button
+            key={layer}
+            onClick={() => toggle(layer)}
+            className={cn(
+              'flex-1 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all border',
+              active
+                ? 'bg-[--color-pgm] text-white border-[--color-pgm]'
+                : 'bg-[--color-surface-raised] text-[--color-text-muted] border-[--color-border] hover:border-[--color-border-strong]',
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ControllerPage/MacroBar.tsx
+++ b/src/pages/ControllerPage/MacroBar.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useMacrosStore } from '@/store/macros.store'
+import { Modal } from '@/components/ui/Modal'
+import { Button } from '@/components/ui/Button'
+import { cn } from '@/lib/cn'
+import type { ApiMacro } from '@/lib/api'
+
+const SLOTS = [0, 1, 2, 3, 4, 5, 6, 7] as const
+
+interface MacroBarProps {
+  productionId: string
+  onExec: (macroId: string) => void
+}
+
+interface MacroFormState {
+  label: string
+  color: string
+  slot: number
+}
+
+function MacroSlot({
+  slot,
+  macro,
+  onExec,
+  onEdit,
+  onEmpty,
+}: {
+  slot: number
+  macro: ApiMacro | undefined
+  onExec: () => void
+  onEdit: () => void
+  onEmpty: () => void
+}) {
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const handlePointerDown = () => {
+    if (!macro) return
+    longPressTimer.current = setTimeout(() => onEdit(), 500)
+  }
+  const handlePointerUp = () => {
+    if (longPressTimer.current) { clearTimeout(longPressTimer.current); longPressTimer.current = undefined }
+  }
+
+  if (!macro) {
+    return (
+      <button
+        onClick={onEmpty}
+        className="flex-1 min-w-[64px] h-10 rounded-lg border border-dashed border-[--color-border] text-[--color-text-muted] text-xs hover:border-[--color-border-strong] transition-colors flex items-center justify-center gap-1"
+        title={`F${slot + 1} — empty slot`}
+      >
+        <span className="text-[9px] text-[--color-text-muted] mr-0.5">F{slot + 1}</span>
+        <span>+</span>
+      </button>
+    )
+  }
+
+  return (
+    <button
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerUp}
+      onClick={onExec}
+      className="flex-1 min-w-[64px] h-10 rounded-lg text-white text-xs font-bold uppercase tracking-wide border border-transparent transition-all active:scale-95 flex flex-col items-center justify-center px-1"
+      style={{ backgroundColor: macro.color }}
+      title={`F${slot + 1} — ${macro.label} (long press to edit)`}
+    >
+      <span className="text-[8px] opacity-60">F{slot + 1}</span>
+      <span className="truncate max-w-full leading-none">{macro.label}</span>
+    </button>
+  )
+}
+
+export function MacroBar({ productionId, onExec }: MacroBarProps) {
+  const { macros, fetchMacros, createMacro, updateMacro, deleteMacro } = useMacrosStore()
+
+  const [editTarget, setEditTarget] = useState<ApiMacro | null>(null)
+  const [createSlot, setCreateSlot] = useState<number | null>(null)
+  const [form, setForm] = useState<MacroFormState>({ label: '', color: '#3B82F6', slot: 0 })
+
+  useEffect(() => {
+    void fetchMacros(productionId)
+  }, [productionId, fetchMacros])
+
+  // F1-F8 keyboard shortcuts
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      const fKeyMatch = e.code.match(/^F([1-8])$/)
+      if (!fKeyMatch) return
+      e.preventDefault()
+      const slot = parseInt(fKeyMatch[1]!, 10) - 1
+      const macro = macros.find((m) => m.slot === slot)
+      if (macro) onExec(macro.id)
+    },
+    [macros, onExec],
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  const openCreate = (slot: number) => {
+    setCreateSlot(slot)
+    setForm({ label: '', color: '#3B82F6', slot })
+  }
+
+  const openEdit = (macro: ApiMacro) => {
+    setEditTarget(macro)
+    setForm({ label: macro.label, color: macro.color, slot: macro.slot })
+  }
+
+  const closeModal = () => { setEditTarget(null); setCreateSlot(null) }
+
+  const handleSave = async () => {
+    if (editTarget) {
+      await updateMacro(productionId, editTarget.id, { label: form.label, color: form.color, slot: form.slot })
+    } else if (createSlot !== null) {
+      await createMacro(productionId, { slot: form.slot, label: form.label, color: form.color, actions: [] })
+    }
+    closeModal()
+  }
+
+  const handleDelete = async () => {
+    if (editTarget) {
+      await deleteMacro(productionId, editTarget.id)
+      closeModal()
+    }
+  }
+
+  const macroBySlot = (slot: number) => macros.find((m) => m.slot === slot)
+
+  return (
+    <>
+      <div className="flex gap-1.5 p-3 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-[--color-text-muted] self-center mr-1 flex-shrink-0">
+          Macros
+        </span>
+        {SLOTS.map((slot) => (
+          <MacroSlot
+            key={slot}
+            slot={slot}
+            macro={macroBySlot(slot)}
+            onExec={() => { const m = macroBySlot(slot); if (m) onExec(m.id) }}
+            onEdit={() => { const m = macroBySlot(slot); if (m) openEdit(m) }}
+            onEmpty={() => openCreate(slot)}
+          />
+        ))}
+      </div>
+
+      {/* Create / Edit modal */}
+      <Modal
+        open={editTarget !== null || createSlot !== null}
+        onClose={closeModal}
+        title={editTarget ? 'Edit Macro' : `New Macro — F${(createSlot ?? 0) + 1}`}
+      >
+        <div className="flex flex-col gap-3 p-4">
+          <label className="flex flex-col gap-1 text-sm">
+            Label
+            <input
+              type="text"
+              maxLength={50}
+              value={form.label}
+              onChange={(e) => setForm((f) => ({ ...f, label: e.target.value }))}
+              className="px-3 py-1.5 rounded bg-[--color-surface-raised] border border-[--color-border] text-[--color-text-primary] text-sm focus:outline-none focus:border-[--color-accent]"
+              placeholder="Go Live"
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            Color
+            <input
+              type="color"
+              value={form.color}
+              onChange={(e) => setForm((f) => ({ ...f, color: e.target.value }))}
+              className="h-9 w-full rounded cursor-pointer"
+            />
+          </label>
+          <p className="text-xs text-[--color-text-muted]">
+            Actions can be configured via the API. UI action editor coming in a future update.
+          </p>
+          <div className={cn('flex gap-2', editTarget ? 'justify-between' : 'justify-end')}>
+            {editTarget && (
+              <Button variant="danger" size="sm" onClick={() => void handleDelete()}>
+                Delete
+              </Button>
+            )}
+            <div className="flex gap-2">
+              <Button variant="default" size="sm" onClick={closeModal}>Cancel</Button>
+              <Button variant="pgm" size="sm" onClick={() => void handleSave()} disabled={!form.label}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/src/pages/ControllerPage/SourceBusDual.tsx
+++ b/src/pages/ControllerPage/SourceBusDual.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useSourcesStore } from '@/store/sources.store'
+import { useProductionStore } from '@/store/production.store'
+import { VideoTile } from '@/components/ui/VideoTile'
+import { useTallyLight } from '@/hooks/useTallyLight'
+import { getSourceStream } from '@/lib/webrtc'
+import { cn } from '@/lib/cn'
+
+function SourceCell({
+  sourceId,
+  role,
+  onClick,
+}: {
+  sourceId: string
+  role: 'pvw' | 'pgm' | 'off'
+  onClick: () => void
+}) {
+  const source = useSourcesStore((s) => s.sources.find((src) => src.id === sourceId))
+  const tally = useTallyLight(sourceId)
+  const [stream, setStream] = useState<MediaStream | null>(null)
+
+  useEffect(() => {
+    if (!source) return
+    let cancelled = false
+    void getSourceStream(source).then((s) => {
+      if (cancelled) { s.getTracks().forEach((t) => t.stop()); return }
+      setStream(s)
+    })
+    return () => {
+      cancelled = true
+      setStream((prev) => { prev?.getTracks().forEach((t) => t.stop()); return null })
+    }
+  }, [source?.id, source?.color, source?.name, source?.liveCamera])
+
+  if (!source) return null
+
+  return (
+    <div
+      className={cn(
+        'w-[120px] flex-shrink-0 rounded overflow-hidden cursor-pointer ring-2 transition-all',
+        role === 'pgm' ? 'ring-[--color-pgm]' : role === 'pvw' ? 'ring-[--color-pvw]' : 'ring-transparent',
+      )}
+      onClick={onClick}
+    >
+      <VideoTile
+        stream={stream}
+        label={source.name}
+        tally={tally}
+        className="w-full"
+      />
+    </div>
+  )
+}
+
+export function SourceBusDual() {
+  const sources = useSourcesStore(useShallow((s) => s.sources))
+  const { pgmSourceId, pvwSourceId, setPvw, cut } = useProductionStore()
+
+  if (sources.length === 0) {
+    return (
+      <div className="p-4 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
+        <p className="text-xs text-[--color-text-muted]">No sources connected</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
+      {/* PVW row */}
+      <div className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold uppercase tracking-widest text-[--color-pvw]">Preview</span>
+        <div className="flex gap-1.5 overflow-x-auto pb-1">
+          {sources.map((src) => (
+            <SourceCell
+              key={src.id}
+              sourceId={src.id}
+              role={src.id === pvwSourceId ? 'pvw' : 'off'}
+              onClick={() => setPvw(src.id)}
+            />
+          ))}
+        </div>
+      </div>
+      {/* PGM row */}
+      <div className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold uppercase tracking-widest text-[--color-pgm]">Program</span>
+        <div className="flex gap-1.5 overflow-x-auto pb-1">
+          {sources.map((src) => (
+            <SourceCell
+              key={src.id}
+              sourceId={src.id}
+              role={src.id === pgmSourceId ? 'pgm' : 'off'}
+              onClick={() => { setPvw(src.id); cut() }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ControllerPage/StreamingStatus.tsx
+++ b/src/pages/ControllerPage/StreamingStatus.tsx
@@ -1,0 +1,32 @@
+import { useStatsStore } from '@/store/stats.store'
+import { cn } from '@/lib/cn'
+
+export function StreamingStatus() {
+  const { active, rtpStats, error } = useStatsStore()
+
+  const dot = !active
+    ? 'bg-zinc-600'
+    : error
+    ? 'bg-red-500'
+    : rtpStats == null
+    ? 'bg-yellow-500'
+    : 'bg-green-500'
+
+  // Best-effort bitrate extraction from rtpStats
+  const bitrate = (() => {
+    if (!rtpStats || typeof rtpStats !== 'object') return null
+    const s = rtpStats as Record<string, unknown>
+    const val = s['bitrate'] ?? s['bit_rate'] ?? s['bytes_sent']
+    if (typeof val === 'number') return `${(val / 1000).toFixed(0)} kbps`
+    return null
+  })()
+
+  return (
+    <div className="flex items-center gap-1.5" title={error ?? (active ? 'Streaming' : 'Not streaming')}>
+      <span className={cn('w-2 h-2 rounded-full flex-shrink-0', dot)} />
+      <span className="text-[10px] font-mono text-[--color-text-muted]">
+        {active ? (bitrate ?? 'Live') : 'Off'}
+      </span>
+    </div>
+  )
+}

--- a/src/pages/ControllerPage/TimerBar.tsx
+++ b/src/pages/ControllerPage/TimerBar.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react'
+import { useProductionStore } from '@/store/production.store'
+
+function formatTime(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+function useClock() {
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+  return now
+}
+
+export function TimerBar() {
+  const isLive = useProductionStore((s) => s.isLive)
+  const now = useClock()
+
+  const goLiveAtRef = useRef<number | null>(null)
+  const [elapsed, setElapsed] = useState(0)
+  const [segment, setSegment] = useState(0)
+  const segmentStartRef = useRef<number>(Date.now())
+
+  // Track go-live start time
+  useEffect(() => {
+    if (isLive) {
+      goLiveAtRef.current = Date.now()
+    } else {
+      goLiveAtRef.current = null
+      setElapsed(0)
+    }
+  }, [isLive])
+
+  // Tick elapsed and segment timers
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (goLiveAtRef.current !== null) {
+        setElapsed(Date.now() - goLiveAtRef.current)
+      }
+      setSegment(Date.now() - segmentStartRef.current)
+    }, 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const resetSegment = () => {
+    segmentStartRef.current = Date.now()
+    setSegment(0)
+  }
+
+  return (
+    <div className="flex items-center gap-4 text-xs font-mono text-[--color-text-muted]">
+      <span title="Wall clock">{now.toLocaleTimeString()}</span>
+      <span className="text-[--color-border]">|</span>
+      <span title="Elapsed since Go Live" className={isLive ? 'text-[--color-pgm]' : ''}>
+        {formatTime(elapsed)}
+      </span>
+      <span className="text-[--color-border]">|</span>
+      <span title="Segment timer">{formatTime(segment)}</span>
+      <button
+        onClick={resetSegment}
+        className="text-[9px] uppercase tracking-widest px-1.5 py-0.5 rounded bg-[--color-surface-raised] border border-[--color-border] hover:bg-[--color-surface-3] transition-colors"
+      >
+        RST
+      </button>
+    </div>
+  )
+}

--- a/src/pages/ControllerPage/index.tsx
+++ b/src/pages/ControllerPage/index.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useCallback, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useWebRTC } from '@/hooks/useWebRTC'
+import { useControllerWs } from '@/hooks/useControllerWs'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { Button } from '@/components/ui/Button'
 import { MultiviewCell } from '@/components/ui/MultiviewCell'
 import { ProgramPreview } from './ProgramPreview'
-import { SourceBus } from './SourceBus'
+import { SourceBusDual } from './SourceBusDual'
 import { TransitionPanel } from './TransitionPanel'
 import { GraphicsPanel } from './GraphicsPanel'
 import { StreamDeckSurface } from './StreamDeckSurface'
+import { DskPanel } from './DskPanel'
+import { AudioPanel } from './AudioPanel'
+import { MacroBar } from './MacroBar'
+import { TimerBar } from './TimerBar'
+import { StreamingStatus } from './StreamingStatus'
 import { useProductionStore } from '@/store/production.store'
 import { useSourcesStore } from '@/store/sources.store'
+import { useStatsStore } from '@/store/stats.store'
 import { cn } from '@/lib/cn'
 
 type GridSize = '2x2' | '3x3' | '4x4'
@@ -21,13 +28,26 @@ const LS_KEY = 'openlive:multiviewer-grid'
 export function ControllerPage() {
   useWebRTC()
 
-  const { isLive, setLive, cut, take } = useProductionStore()
+  const { isLive, setLive, cut, take, activeProductionId } = useProductionStore()
+  const send = useControllerWs(activeProductionId)
+  const startPolling = useStatsStore((s) => s.startPolling)
+  const stopPolling = useStatsStore((s) => s.stopPolling)
 
   const [gridSize, setGridSize] = useState<GridSize>(() =>
     (localStorage.getItem(LS_KEY) as GridSize | null) ?? '2x2'
   )
 
   useEffect(() => { localStorage.setItem(LS_KEY, gridSize) }, [gridSize])
+
+  // Start/stop streaming stats polling with the active production
+  useEffect(() => {
+    if (activeProductionId) {
+      startPolling(activeProductionId)
+    } else {
+      stopPolling()
+    }
+    return () => stopPolling()
+  }, [activeProductionId, startPolling, stopPolling])
 
   const sources = useSourcesStore(useShallow((s) =>
     s.sources.slice(0, GRID_MAX[gridSize])
@@ -44,6 +64,20 @@ export function ControllerPage() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
 
+  const handleGoLive = () => {
+    const next = !isLive
+    setLive(next)
+    send(next ? { type: 'GO_LIVE' } : { type: 'CUT_STREAM' })
+  }
+
+  const handleDskToggle = (layer: number, visible: boolean) => {
+    send({ type: 'DSK_TOGGLE', layer, visible })
+  }
+
+  const handleMacroExec = (macroId: string) => {
+    send({ type: 'MACRO_EXEC', macroId })
+  }
+
   const cols = GRID_COLS[gridSize]
   const maxCells = GRID_MAX[gridSize]
   const emptyCells = Math.max(0, maxCells - sources.length)
@@ -54,19 +88,40 @@ export function ControllerPage() {
         title="Controller"
         subtitle="Space = Cut  ·  Enter = Take"
         actions={
-          <Button
-            variant={isLive ? 'pgm' : 'default'}
-            size="md"
-            onClick={() => setLive(!isLive)}
-          >
-            {isLive ? '● ON AIR' : '○ Go Live'}
-          </Button>
+          <div className="flex items-center gap-4">
+            <TimerBar />
+            <StreamingStatus />
+            <Button
+              variant={isLive ? 'pgm' : 'default'}
+              size="md"
+              onClick={handleGoLive}
+            >
+              {isLive ? '● ON AIR' : '○ Go Live'}
+            </Button>
+          </div>
         }
       />
 
       <div className="flex-1 overflow-auto p-4 flex flex-col gap-4">
-        {/* PGM / PVW monitors */}
-        <ProgramPreview />
+        {/* Main 3-column layout on large screens */}
+        <div className="grid grid-cols-1 lg:grid-cols-[auto_1fr_auto] gap-4 items-start">
+          {/* Left: Source Bus */}
+          <div className="lg:w-64 xl:w-72">
+            <SourceBusDual />
+          </div>
+
+          {/* Centre: PGM/PVW + Transitions + DSK */}
+          <div className="flex flex-col gap-3">
+            <ProgramPreview />
+            <TransitionPanel />
+            <DskPanel onToggle={handleDskToggle} />
+          </div>
+
+          {/* Right: Audio */}
+          <div className="lg:w-56 xl:w-64">
+            <AudioPanel />
+          </div>
+        </div>
 
         {/* Multiviewer */}
         <div className="flex flex-col gap-3 p-4 bg-[--color-surface-3] rounded-xl border border-[--color-border]">
@@ -103,14 +158,13 @@ export function ControllerPage() {
           </div>
         </div>
 
-        {/* Source bus */}
-        <SourceBus />
+        {/* Macro bar */}
+        {activeProductionId && (
+          <MacroBar productionId={activeProductionId} onExec={handleMacroExec} />
+        )}
 
-        {/* Transition + Graphics */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <TransitionPanel />
-          <GraphicsPanel />
-        </div>
+        {/* Graphics */}
+        <GraphicsPanel />
 
         {/* Stream Deck */}
         <StreamDeckSurface />

--- a/src/pages/TallyPage/index.tsx
+++ b/src/pages/TallyPage/index.tsx
@@ -1,0 +1,80 @@
+import { useShallow } from 'zustand/react/shallow'
+import { useSourcesStore } from '@/store/sources.store'
+import { useProductionStore } from '@/store/production.store'
+import { useTallyLight } from '@/hooks/useTallyLight'
+import { cn } from '@/lib/cn'
+
+function TallyBlock({ sourceId }: { sourceId: string }) {
+  const source = useSourcesStore((s) => s.sources.find((src) => src.id === sourceId))
+  const tally = useTallyLight(sourceId)
+
+  if (!source) return null
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center rounded-2xl border-4 transition-colors',
+        tally === 'pgm'
+          ? 'bg-red-950 border-red-500'
+          : tally === 'pvw'
+          ? 'bg-green-950 border-green-500'
+          : 'bg-zinc-950 border-zinc-800',
+      )}
+      style={{ minHeight: '180px' }}
+    >
+      <span
+        className={cn(
+          'text-4xl font-black uppercase tracking-widest',
+          tally === 'pgm' ? 'text-red-400' : tally === 'pvw' ? 'text-green-400' : 'text-zinc-700',
+        )}
+      >
+        {tally === 'pgm' ? 'PGM' : tally === 'pvw' ? 'PVW' : '—'}
+      </span>
+      <span
+        className={cn(
+          'text-lg font-semibold mt-2',
+          tally === 'pgm' ? 'text-red-300' : tally === 'pvw' ? 'text-green-300' : 'text-zinc-600',
+        )}
+      >
+        {source.name}
+      </span>
+    </div>
+  )
+}
+
+export function TallyPage() {
+  const sources = useSourcesStore(useShallow((s) => s.sources))
+  const isLive = useProductionStore((s) => s.isLive)
+
+  return (
+    <div className="min-h-screen bg-black p-4 flex flex-col gap-4">
+      {/* ON AIR indicator */}
+      <div className="flex justify-center">
+        <div
+          className={cn(
+            'px-8 py-2 rounded-full text-sm font-black uppercase tracking-[0.3em]',
+            isLive ? 'bg-red-600 text-white animate-pulse' : 'bg-zinc-900 text-zinc-700',
+          )}
+        >
+          {isLive ? '● ON AIR' : '○ OFF AIR'}
+        </div>
+      </div>
+
+      {/* Tally grid */}
+      {sources.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-zinc-700 text-lg uppercase tracking-widest">No sources</p>
+        </div>
+      ) : (
+        <div
+          className="grid gap-3"
+          style={{ gridTemplateColumns: `repeat(${Math.min(sources.length, 4)}, 1fr)` }}
+        >
+          {sources.map((src) => (
+            <TallyBlock key={src.id} sourceId={src.id} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/store/audio.store.ts
+++ b/src/store/audio.store.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { devtools } from 'zustand/middleware'
+import { audioApi, type ApiAudioElement } from '@/lib/api'
+
+// Throttle: max one PATCH per elementId per 100ms
+const pendingThrottle = new Map<string, ReturnType<typeof setTimeout>>()
+
+function throttledUpdate(productionId: string, elementId: string, property: string, value: unknown) {
+  if (pendingThrottle.has(elementId)) return
+  const timer = setTimeout(() => {
+    pendingThrottle.delete(elementId)
+    void audioApi.updateElement(productionId, elementId, { property, value })
+  }, 100)
+  pendingThrottle.set(elementId, timer)
+}
+
+interface AudioState {
+  elements: ApiAudioElement[]
+  levels: Record<string, number>      // elementId → 0.0–1.0
+  muted: Record<string, boolean>      // elementId → boolean
+  productionId: string | null
+}
+
+interface AudioActions {
+  setElements: (elements: ApiAudioElement[], productionId: string) => void
+  setLevel: (elementId: string, value: number) => void
+  toggleMute: (elementId: string) => void
+}
+
+export const useAudioStore = create<AudioState & AudioActions>()(
+  devtools(
+    immer((set, get) => ({
+      elements: [],
+      levels: {},
+      muted: {},
+      productionId: null,
+
+      setElements: (elements, productionId) =>
+        set((s) => {
+          s.elements = elements
+          s.productionId = productionId
+          // Initialise levels to 1.0 and muted to false for new elements
+          elements.forEach((el) => {
+            if (s.levels[el.elementId] === undefined) s.levels[el.elementId] = 1.0
+            if (s.muted[el.elementId] === undefined) s.muted[el.elementId] = false
+          })
+        }),
+
+      setLevel: (elementId, value) => {
+        const clamped = Math.max(0, Math.min(1, value))
+        set((s) => { s.levels[elementId] = clamped })
+        const { productionId } = get()
+        if (productionId) throttledUpdate(productionId, elementId, 'volume', clamped)
+      },
+
+      toggleMute: (elementId) => {
+        set((s) => { s.muted[elementId] = !s.muted[elementId] })
+        const { muted, productionId } = get()
+        if (productionId) {
+          void audioApi.updateElement(productionId, elementId, {
+            property: 'mute',
+            value: muted[elementId],
+          })
+        }
+      },
+    })),
+    { name: 'audio' },
+  ),
+)

--- a/src/store/macros.store.ts
+++ b/src/store/macros.store.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { devtools } from 'zustand/middleware'
+import { macrosApi, type ApiMacro } from '@/lib/api'
+
+interface MacrosState {
+  macros: ApiMacro[]
+  loading: boolean
+  productionId: string | null
+}
+
+interface MacrosActions {
+  fetchMacros: (productionId: string) => Promise<void>
+  createMacro: (productionId: string, body: Omit<ApiMacro, 'id'>) => Promise<ApiMacro>
+  updateMacro: (productionId: string, macroId: string, body: Partial<Omit<ApiMacro, 'id'>>) => Promise<void>
+  deleteMacro: (productionId: string, macroId: string) => Promise<void>
+  applyWsUpdate: (macro: ApiMacro) => void
+}
+
+export const useMacrosStore = create<MacrosState & MacrosActions>()(
+  devtools(
+    immer((set) => ({
+      macros: [],
+      loading: false,
+      productionId: null,
+
+      fetchMacros: async (productionId) => {
+        set((s) => { s.loading = true; s.productionId = productionId })
+        try {
+          const macros = await macrosApi.list(productionId)
+          set((s) => { s.macros = macros; s.loading = false })
+        } catch {
+          set((s) => { s.loading = false })
+        }
+      },
+
+      createMacro: async (productionId, body) => {
+        const macro = await macrosApi.create(productionId, body)
+        set((s) => { s.macros.push(macro) })
+        return macro
+      },
+
+      updateMacro: async (productionId, macroId, body) => {
+        const updated = await macrosApi.update(productionId, macroId, body)
+        set((s) => {
+          const idx = s.macros.findIndex((m) => m.id === macroId)
+          if (idx !== -1) s.macros[idx] = updated
+        })
+      },
+
+      deleteMacro: async (productionId, macroId) => {
+        await macrosApi.remove(productionId, macroId)
+        set((s) => { s.macros = s.macros.filter((m) => m.id !== macroId) })
+      },
+
+      applyWsUpdate: (macro) => {
+        set((s) => {
+          const idx = s.macros.findIndex((m) => m.id === macro.id)
+          if (idx !== -1) s.macros[idx] = macro
+        })
+      },
+    })),
+    { name: 'macros' },
+  ),
+)

--- a/src/store/stats.store.ts
+++ b/src/store/stats.store.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { devtools } from 'zustand/middleware'
+import { statsApi, type ApiStreamingStats } from '@/lib/api'
+
+const POLL_INTERVAL_MS = 2000
+
+interface StatsState {
+  active: boolean
+  rtpStats: unknown
+  webrtcStats: unknown
+  error: string | undefined
+  polling: boolean
+}
+
+interface StatsActions {
+  startPolling: (productionId: string) => void
+  stopPolling: () => void
+}
+
+let intervalId: ReturnType<typeof setInterval> | undefined
+
+export const useStatsStore = create<StatsState & StatsActions>()(
+  devtools(
+    immer((set) => ({
+      active: false,
+      rtpStats: undefined,
+      webrtcStats: undefined,
+      error: undefined,
+      polling: false,
+
+      startPolling: (productionId) => {
+        if (intervalId) clearInterval(intervalId)
+        set((s) => { s.polling = true })
+
+        const poll = async () => {
+          try {
+            const result: ApiStreamingStats = await statsApi.streaming(productionId)
+            set((s) => {
+              s.active = result.active
+              s.rtpStats = result.rtpStats
+              s.webrtcStats = result.webrtcStats
+              s.error = result.error
+            })
+          } catch (err) {
+            set((s) => { s.error = err instanceof Error ? err.message : String(err) })
+          }
+        }
+
+        void poll()
+        intervalId = setInterval(() => { void poll() }, POLL_INTERVAL_MS)
+      },
+
+      stopPolling: () => {
+        if (intervalId) { clearInterval(intervalId); intervalId = undefined }
+        set((s) => { s.polling = false; s.active = false })
+      },
+    })),
+    { name: 'stats' },
+  ),
+)

--- a/src/store/stream-deck.store.ts
+++ b/src/store/stream-deck.store.ts
@@ -8,6 +8,8 @@ export type ButtonAction =
   | { type: 'go-live' }
   | { type: 'graphic-toggle'; graphicId: string }
   | { type: 'transition'; mode: 'cut' | 'mix' | 'wipe' }
+  | { type: 'dsk-toggle'; layer: number }
+  | { type: 'macro-exec'; macroId: string }
   | { type: 'none' }
 
 export interface StreamDeckButton {


### PR DESCRIPTION
Closes #1

## Summary

- **Two-row source bus** (`SourceBusDual`) — PVW row (click to preview) + PGM row (click to cut), tally-coloured borders
- **Audio panel** (`AudioPanel`) — per-element vertical faders with VU meters, mute buttons, 100ms throttle on API calls
- **DSK 1/2 controls** (`DskPanel`) — toggle buttons wired to `DSK_TOGGLE` WebSocket message
- **Macro bar** (`MacroBar`) — 8 configurable buttons (F1–F8), create/edit modal, long-press to edit, macros persisted via backend API
- **Production timer + clock** (`TimerBar`) — wall clock, elapsed since Go Live, resettable segment timer
- **Streaming status** (`StreamingStatus`) — health dot (green/yellow/red) + bitrate from Strom rtpStats
- **Tally page** (`/tally`) — full-screen tally view for camera operators, standalone route (no Shell/auth)
- **WebSocket client** (`useControllerWs`) — connects to `/ws/productions/:id/controller`, syncs TALLY/ON_AIR events into production store, exposes `send()` for DSK_TOGGLE and MACRO_EXEC

**New stores:** `macros.store`, `audio.store` (throttled fader updates), `stats.store` (2s polling)  
**Stream Deck:** added `dsk-toggle` and `macro-exec` to `ButtonAction` union

All existing functionality preserved: Space=Cut, Enter=Take, multiviewer grid, graphics panel, Stream Deck surface.

## Test plan

- [ ] Navigate to `/controller` — new 3-column layout renders
- [ ] Source bus shows two rows (PVW / PGM) with correct tally borders
- [ ] DSK 1 / DSK 2 buttons toggle and show active state
- [ ] F1–F8 keys trigger macros (when not focused on input)
- [ ] MacroBar "+" button opens create modal; long-press opens edit modal
- [ ] TimerBar starts counting on Go Live, resets on segment RST
- [ ] StreamingStatus shows green dot when pipeline active
- [ ] Navigate to `/tally` — full-screen tally, no nav chrome
- [ ] TypeScript: `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)