### PR TITLE
feat(activation): async activation state, WHEP client, and live multiviewer in controller

### DIFF
--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -1,32 +1,86 @@
 import { useEffect } from 'react'
 import { useViewerStore } from '@/store/viewer.store'
+import { useProductionStore } from '@/store/production.store'
+import { useProductionsStore } from '@/store/productions.store'
 import { getViewerStream } from '@/lib/webrtc'
+import { connectWhep } from '@/lib/whep'
+import { iceServersApi } from '@/lib/api'
 
 /**
  * Initialises the viewer stream on mount.
- * Uses real camera via getUserMedia, falls back to canvas color bars.
+ *
+ * When the active production has status 'active' and a whepEndpoint:
+ *   - Fetches ICE servers from GET /api/v1/ice-servers (never hardcoded)
+ *   - Connects via WHEP to the live multiview stream
+ *   - On failure: falls back to color bars via getViewerStream()
+ *
+ * Otherwise: existing behavior (getUserMedia / color bars).
+ *
+ * Re-runs when whepEndpoint changes (e.g. activation completes).
+ *
+ * See spec: docs/specs/activation-whep.md §6.1
  * See docs/repo-patterns.md: "WebRTC viewer fails on mobile without TURN"
+ * See docs/repo-patterns.md: "Safari requires playsinline autoplay muted"
  */
 export function useWebRTC(): void {
   const setProgramStream = useViewerStore((s) => s.setProgramStream)
   const setConnectionState = useViewerStore((s) => s.setConnectionState)
   const disconnect = useViewerStore((s) => s.disconnect)
 
+  const activeProductionId = useProductionStore((s) => s.activeProductionId)
+  const productions = useProductionsStore((s) => s.productions)
+
+  const activeProd = activeProductionId
+    ? productions.find((p) => p.id === activeProductionId)
+    : undefined
+
+  const whepEndpoint =
+    activeProd?.status === 'active' ? (activeProd.whepEndpoint ?? null) : null
+
   useEffect(() => {
     let cancelled = false
+    let closeWhep: (() => void) | null = null
     setConnectionState('connecting')
 
-    void getViewerStream().then(({ stream, isMock }) => {
+    async function connect(): Promise<void> {
+      if (whepEndpoint) {
+        try {
+          const { iceServers } = await iceServersApi.get()
+          if (cancelled) return
+          const { stream, close } = await connectWhep(whepEndpoint, iceServers)
+          if (cancelled) {
+            close()
+            return
+          }
+          closeWhep = close
+          setProgramStream(stream, false)
+          return
+        } catch (err) {
+          console.warn('[useWebRTC] WHEP connection failed, falling back to mock stream:', err)
+          if (cancelled) return
+        }
+      }
+
+      // Fallback: getUserMedia or color bars
+      const { stream, isMock } = await getViewerStream()
       if (cancelled) {
         stream.getTracks().forEach((t) => t.stop())
         return
       }
       setProgramStream(stream, isMock)
-    })
+    }
+
+    void connect()
 
     return () => {
       cancelled = true
+      if (closeWhep) {
+        closeWhep()
+        closeWhep = null
+      }
       disconnect()
     }
-  }, [setProgramStream, setConnectionState, disconnect])
+    // Re-run when whepEndpoint changes (activation may complete while hook is mounted)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [whepEndpoint, setProgramStream, setConnectionState, disconnect])
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -32,10 +32,11 @@ export interface ProductionSourceAssignment {
 export interface ApiProduction {
   id: string
   name: string
-  status: 'active' | 'inactive'
+  status: 'active' | 'inactive' | 'activating'
   sources: ProductionSourceAssignment[]
   templateId?: string
   stromFlowId?: string
+  whepEndpoint?: string
 }
 
 export interface ApiTemplate {
@@ -59,10 +60,11 @@ export interface ApiTemplate {
 type RawProduction = {
   _id: string
   name: string
-  status: 'active' | 'inactive'
+  status: 'active' | 'inactive' | 'activating'
   sources: ProductionSourceAssignment[]
   templateId?: string
   stromFlowId?: string
+  whepEndpoint?: string
 }
 
 function normalizeProduction(d: RawProduction): ApiProduction {
@@ -73,6 +75,7 @@ function normalizeProduction(d: RawProduction): ApiProduction {
     sources: d.sources ?? [],
     templateId: d.templateId,
     stromFlowId: d.stromFlowId,
+    whepEndpoint: d.whepEndpoint,
   }
 }
 
@@ -80,6 +83,10 @@ export const productionsApi = {
   list: () =>
     request<RawProduction[]>('/api/v1/productions')
       .then((docs) => docs.map(normalizeProduction)),
+
+  get: (id: string) =>
+    request<RawProduction>(`/api/v1/productions/${id}`)
+      .then(normalizeProduction),
 
   create: (body: { name: string }) =>
     request<RawProduction>('/api/v1/productions', {
@@ -207,6 +214,11 @@ export const audioApi = {
 export const statsApi = {
   streaming: (productionId: string) =>
     request<ApiStreamingStats>(`/api/v1/productions/${productionId}/stats/streaming`),
+}
+
+export const iceServersApi = {
+  get: () =>
+    request<{ iceServers: RTCIceServer[] }>('/api/v1/ice-servers'),
 }
 
 export const templatesApi = {

--- a/src/lib/whep.ts
+++ b/src/lib/whep.ts
@@ -22,6 +22,20 @@ export async function connectWhep(
   pc.addTransceiver('video', { direction: 'recvonly' })
   pc.addTransceiver('audio', { direction: 'recvonly' })
 
+  // Assign ontrack BEFORE setLocalDescription/setRemoteDescription.
+  // In Chromium and Safari, ontrack events can fire synchronously during
+  // setRemoteDescription processing — assigning the handler late silently
+  // drops those tracks, leaving the viewer black.
+  const stream = new MediaStream()
+  pc.ontrack = (event) => {
+    const incomingStream = event.streams[0] ?? new MediaStream([event.track])
+    incomingStream.getTracks().forEach((t) => {
+      if (!stream.getTracks().includes(t)) {
+        stream.addTrack(t)
+      }
+    })
+  }
+
   // Create offer and set as local description
   const offer = await pc.createOffer()
   await pc.setLocalDescription(offer)
@@ -57,12 +71,6 @@ export async function connectWhep(
 
   const answerSdp = await response.text()
   await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp })
-
-  // Collect incoming tracks into a MediaStream
-  const stream = new MediaStream()
-  pc.ontrack = (event) => {
-    stream.addTrack(event.track)
-  }
 
   // Wait for ICE to reach 'connected' state within the timeout
   await new Promise<void>((resolve, reject) => {

--- a/src/lib/whep.ts
+++ b/src/lib/whep.ts
@@ -1,0 +1,112 @@
+/**
+ * WHEP (WebRTC-HTTP Egress Protocol) client.
+ *
+ * Connects to a WHEP endpoint and returns a MediaStream containing the
+ * video and audio tracks from the remote sender.
+ *
+ * See spec: docs/specs/activation-whep.md §5
+ * See CLAUDE.md: "never polyfill the media layer" — standard RTCPeerConnection only
+ * See docs/repo-patterns.md: "Safari requires playsinline autoplay muted"
+ */
+
+const WHEP_ICE_TIMEOUT_MS = 15000
+
+export async function connectWhep(
+  whepUrl: string,
+  iceServers: RTCIceServer[],
+): Promise<{ stream: MediaStream; close: () => void }> {
+  const pc = new RTCPeerConnection({ iceServers })
+  let whepResourceUrl: string | null = null
+
+  // Add recvonly transceivers so the offer includes a/v m-lines
+  pc.addTransceiver('video', { direction: 'recvonly' })
+  pc.addTransceiver('audio', { direction: 'recvonly' })
+
+  // Create offer and set as local description
+  const offer = await pc.createOffer()
+  await pc.setLocalDescription(offer)
+
+  // POST the offer SDP to the WHEP endpoint
+  let response: Response
+  try {
+    response = await fetch(whepUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: offer.sdp,
+    })
+  } catch (fetchErr) {
+    pc.close()
+    throw new Error(`WHEP: network error posting offer: ${String(fetchErr)}`)
+  }
+
+  if (response.status !== 201) {
+    pc.close()
+    throw new Error(`WHEP: unexpected status ${response.status} from ${whepUrl}`)
+  }
+
+  // Capture the teardown URL from the Location header
+  const location = response.headers.get('Location')
+  if (location) {
+    // Resolve relative URLs against the WHEP endpoint origin
+    try {
+      whepResourceUrl = new URL(location, whepUrl).toString()
+    } catch {
+      whepResourceUrl = location
+    }
+  }
+
+  const answerSdp = await response.text()
+  await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp })
+
+  // Collect incoming tracks into a MediaStream
+  const stream = new MediaStream()
+  pc.ontrack = (event) => {
+    stream.addTrack(event.track)
+  }
+
+  // Wait for ICE to reach 'connected' state within the timeout
+  await new Promise<void>((resolve, reject) => {
+    // Already connected (fast-path for localhost / relay-less paths)
+    if (
+      pc.iceConnectionState === 'connected' ||
+      pc.iceConnectionState === 'completed'
+    ) {
+      resolve()
+      return
+    }
+
+    const timer = setTimeout(() => {
+      reject(new Error(`WHEP: ICE connection timed out after ${WHEP_ICE_TIMEOUT_MS}ms`))
+    }, WHEP_ICE_TIMEOUT_MS)
+
+    pc.oniceconnectionstatechange = () => {
+      const s = pc.iceConnectionState
+      if (s === 'connected' || s === 'completed') {
+        clearTimeout(timer)
+        resolve()
+      } else if (s === 'failed' || s === 'closed') {
+        clearTimeout(timer)
+        reject(new Error(`WHEP: ICE connection failed (state: ${s})`))
+      }
+    }
+  }).catch((err: unknown) => {
+    // Clean up and re-throw so the caller can fall back to mock stream
+    pc.close()
+    stream.getTracks().forEach((t) => t.stop())
+    throw err
+  })
+
+  function close(): void {
+    pc.close()
+    stream.getTracks().forEach((t) => t.stop())
+
+    // Best-effort DELETE to release the WHEP server-side session
+    if (whepResourceUrl) {
+      fetch(whepResourceUrl, { method: 'DELETE' }).catch((err: unknown) => {
+        console.warn('[whep] DELETE resource failed (best-effort):', err)
+      })
+    }
+  }
+
+  return { stream, close }
+}

--- a/src/pages/SetupPage/ProductionsPanel.tsx
+++ b/src/pages/SetupPage/ProductionsPanel.tsx
@@ -308,6 +308,7 @@ export function ProductionsPanel() {
       <div className="flex flex-col gap-2">
         {productions.map((prod) => {
           const isActive = prod.status === 'active'
+          const isActivating = prod.status === 'activating'
           const template = templates.find((t) => t.id === prod.templateId)
           const assignedCount = prod.sources.length
           const totalSlots = template?.inputs.length ?? 0
@@ -323,7 +324,10 @@ export function ProductionsPanel() {
             >
               {/* Top row */}
               <div className="flex items-center gap-3">
-                <StatusDot color={isActive ? 'red' : 'gray'} />
+                <StatusDot
+                  color={isActive ? 'red' : isActivating ? 'yellow' : 'gray'}
+                  pulse={isActivating}
+                />
                 <div className="flex-1 min-w-0">
                   <span className="text-sm font-medium text-[--color-text-primary] truncate block">
                     {prod.name}
@@ -345,24 +349,43 @@ export function ProductionsPanel() {
                       size="sm"
                       variant="ghost"
                       onClick={() => setConfiguringId(prod.id)}
+                      disabled={isActivating}
                     >
                       ⚙ Sources
                     </Button>
                   )}
-                  <Button
-                    size="sm"
-                    variant={isActive ? 'ghost' : 'pvw'}
-                    onClick={() => {
-                      void updateStatus(prod.id, isActive ? 'inactive' : 'active')
-                      setActiveProduction(isActive ? null : prod.id)
-                    }}
-                  >
-                    {isActive ? 'Deactivate' : 'Activate'}
-                  </Button>
+                  {isActive ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={isActivating}
+                      onClick={() => {
+                        void updateStatus(prod.id, 'inactive')
+                        setActiveProduction(null)
+                      }}
+                    >
+                      Deactivate
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="pvw"
+                      disabled={isActivating}
+                      onClick={() => {
+                        if (!isActivating) {
+                          void updateStatus(prod.id, 'active')
+                          setActiveProduction(prod.id)
+                        }
+                      }}
+                    >
+                      {isActivating ? 'Activating...' : 'Activate'}
+                    </Button>
+                  )}
                   <Button
                     size="sm"
                     variant="ghost"
                     onClick={() => handleDelete(prod.id)}
+                    disabled={isActivating}
                     className="opacity-40 hover:opacity-100"
                   >
                     ✕

--- a/src/store/productions.store.ts
+++ b/src/store/productions.store.ts
@@ -3,7 +3,10 @@ import { immer } from 'zustand/middleware/immer'
 import { devtools } from 'zustand/middleware'
 import { productionsApi, type ApiProduction, type ProductionSourceAssignment } from '@/lib/api'
 
-export type ProductionStatus = 'active' | 'inactive'
+export type ProductionStatus = 'active' | 'inactive' | 'activating'
+
+const ACTIVATION_POLL_INTERVAL_MS = 1000
+const ACTIVATION_POLL_TIMEOUT_MS = 35000
 
 export interface Production {
   id: string
@@ -12,6 +15,7 @@ export interface Production {
   sources: ProductionSourceAssignment[]
   templateId?: string
   stromFlowId?: string
+  whepEndpoint?: string
 }
 
 interface ProductionsState {
@@ -38,6 +42,7 @@ function fromApi(p: ApiProduction): Production {
     sources: p.sources ?? [],
     templateId: p.templateId,
     stromFlowId: p.stromFlowId,
+    whepEndpoint: p.whepEndpoint,
   }
 }
 
@@ -83,8 +88,40 @@ export const useProductionsStore = create<ProductionsState & ProductionsActions>
           if (prod) {
             prod.status = updated.status
             prod.stromFlowId = updated.stromFlowId
+            prod.whepEndpoint = updated.whepEndpoint
           }
         })
+
+        if (updated.status === 'activating') {
+          // Poll until status is no longer 'activating' or timeout is reached
+          const deadline = Date.now() + ACTIVATION_POLL_TIMEOUT_MS
+          const poll = async (): Promise<void> => {
+            if (Date.now() >= deadline) {
+              console.warn(`[productions] Activation polling timed out for production ${id}`)
+              return
+            }
+            await new Promise<void>((resolve) => setTimeout(resolve, ACTIVATION_POLL_INTERVAL_MS))
+            try {
+              const polled = await productionsApi.get(id)
+              set((state) => {
+                const prod = state.productions.find((p) => p.id === id)
+                if (prod) {
+                  prod.status = polled.status
+                  prod.stromFlowId = polled.stromFlowId
+                  prod.whepEndpoint = polled.whepEndpoint
+                }
+              })
+              if (polled.status === 'activating') {
+                await poll()
+              }
+            } catch (err) {
+              console.error(`[productions] Activation poll error for ${id}:`, err)
+              // Retry on network error unless past deadline
+              await poll()
+            }
+          }
+          await poll()
+        }
       },
 
       updateTemplateId: async (id, templateId) => {


### PR DESCRIPTION
## Summary

- **Async activation state**: adds `'activating'` as a new `ProductionStatus`. The activate API now returns immediately with `status: 'activating'`; the frontend polls `GET /api/v1/productions/:id` every 1 s (max 35 s) until the status resolves to `'active'` or `'inactive'`.
- **WHEP client** (`src/lib/whep.ts`): standard `RTCPeerConnection`-based client. POSTs an SDP offer, sets the answer, waits for ICE `connected` within 15 s, and cleans up via `DELETE` on the Location URL on teardown.
- **Live multiviewer**: `useWebRTC` hook now attempts a WHEP connection (with ICE servers fetched from `GET /api/v1/ice-servers`) when the active production has `status === 'active'` and a `whepEndpoint`. Falls back to color bars on failure. Re-runs when `whepEndpoint` changes.
- **UI activating state** (`ProductionsPanel`): yellow pulsing `StatusDot`, disabled Activate/Deactivate/Delete buttons, and "Activating..." button label during the `'activating'` window.

## Files changed

- `src/lib/api.ts` — `ApiProduction`, `RawProduction`, `normalizeProduction`, `productionsApi.get`, `iceServersApi`
- `src/store/productions.store.ts` — `ProductionStatus`, `Production.whepEndpoint`, `fromApi`, activation polling in `updateStatus`
- `src/lib/whep.ts` *(new)* — WHEP client
- `src/hooks/useWebRTC.ts` — WHEP integration with fallback
- `src/pages/SetupPage/ProductionsPanel.tsx` — activating state UI

## Test plan

- [ ] Activate a production: status dot turns yellow and pulses, buttons disabled, "Activating..." label shown
- [ ] After backend resolves: dot turns red, buttons re-enable, PGM view connects via WHEP
- [ ] WHEP failure (bad endpoint): hook falls back to color bars without crashing
- [ ] Deactivate: dot turns gray, `whepEndpoint` cleared, PGM falls back to color bars
- [ ] 35 s timeout: if backend never resolves, polling stops and console warns
- [ ] Safari: video element must have `playsinline autoplay muted` (existing `ProgramPreview` markup — verify unchanged)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)