### PR TITLE
fix: align start script env vars with app's runtime config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "start": "node -e \"const fs=require('fs');fs.writeFileSync('dist/env-config.js','window._env_='+JSON.stringify({VITE_API_URL:process.env.VITE_API_URL||''})+';')\" && serve -s dist --listen ${PORT:-8080}",
+    "start": "node -e \"const fs=require('fs');fs.writeFileSync('dist/env-config.js','window._env_='+JSON.stringify({OPEN_LIVE_URL:process.env.OPEN_LIVE_URL||'',OSC_PAT:process.env.OSC_PAT||''})+';')\" && serve -s dist --listen ${PORT:-8080}",
     "preview": "vite preview",
     "lint": "eslint src --max-warnings=0",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

The `start` script in `package.json` writes `VITE_API_URL` to `env-config.js`, but every consumer of the runtime config reads `window._env_.OPEN_LIVE_URL` (via `src/lib/base.ts`). In non-Docker deployments using `pnpm start`, `OPEN_LIVE_URL` is always `undefined` and the backend URL silently falls back to `http://localhost:3000`.

## Change

Changed the start script to write `OPEN_LIVE_URL` instead of `VITE_API_URL`, matching what the application actually reads. Also added `OSC_PAT` passthrough for runtime auth configuration.

## Files changed

- `package.json`: Updated start script env-config.js generation

Closes #11