### PR TITLE
fix: add Cache-Control: no-store for env-config.js in nginx config (closes #20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ RUN printf 'server {\n\
     root /usr/share/nginx/html;\n\
     index index.html;\n\
     add_header X-Frame-Options "SAMEORIGIN" always;\n\
+    location = /env-config.js {\n\
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;\n\
+        add_header Pragma "no-cache" always;\n\
+    }\n\
     location / {\n\
         try_files $uri $uri/ /index.html;\n\
     }\n\


### PR DESCRIPTION
## Summary

- Added a precise `location = /env-config.js` block in the nginx config template (inside the Dockerfile) with `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache`
- This file is regenerated on every container start and contains `OPEN_LIVE_URL` and `OSC_PAT`; without explicit headers, browsers/proxies apply heuristic caching which extends the exposure window after a credential rotation

## Test plan

- [ ] Build and run the container
- [ ] `curl -I http://localhost:8080/env-config.js` — response includes `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] Verify other routes (e.g. `/`) still return `X-Frame-Options: SAMEORIGIN`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)