### PR TITLE
fix: move serve to dependencies so npm start works without devDeps (closes #17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.5.1",
+    "serve": "^14.2.6",
     "tailwind-merge": "^3.2.0",
     "zustand": "^5.0.3"
   },
@@ -30,7 +31,6 @@
     "eslint": "^9.24.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.0.0",
-    "serve": "^14.2.6",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-router:
         specifier: ^7.5.1
         version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      serve:
+        specifier: ^14.2.6
+        version: 14.2.6
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.5.0
@@ -54,9 +57,6 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.5.0
-      serve:
-        specifier: ^14.2.6
-        version: 14.2.6
       tailwindcss:
         specifier: ^4.1.4
         version: 4.2.2


### PR DESCRIPTION
## Summary

- Moved `serve` from `devDependencies` to `dependencies` in `package.json`
- Regenerated `pnpm-lock.yaml` accordingly

The `start` script calls `serve` to host the built frontend, but `serve` was listed under `devDependencies`. Running `npm install --production` (or `npm ci --omit=dev`) would skip installing `serve`, causing `npm start` to fail silently in production deployments that omit dev packages.

Closes #17