### PR TITLE
fix: pin @osaas/cli to 4.31.3 and remove unused env var (closes #18)

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -20,10 +20,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install OSC CLI
-        run: npm install -g @osaas/cli
+        run: npm install -g @osaas/cli@4.31.3
 
       - name: Trigger sync fork
         env:
-          OSC_ACCESS_TOKEN: unused
           OSC_API_KEY: ${{ secrets.OSC_API_KEY }}
         run: osc --env ${{ inputs.environment }} admin sync-fork eyevinn-open-live-studio


### PR DESCRIPTION
## Summary

- Pins `@osaas/cli` to version `4.31.3` in `.github/workflows/sync-fork.yml`, eliminating the supply-chain risk of pulling an unpinned `latest` package on every workflow run.
- Removes the `OSC_ACCESS_TOKEN: unused` placeholder environment variable that was causing confusion.

## Test plan
- [ ] Trigger the `sync-fork.yml` workflow manually and verify it completes successfully with the pinned CLI version.
- [ ] Confirm the `OSC_ACCESS_TOKEN` removal doesn't break anything (it was already set to the literal string `unused`).

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)