### PR TITLE
fix: add CSP and security headers to nginx config (closes #8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,20 +19,8 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-RUN printf 'server {\n\
-    listen %PORT%;\n\
-    root /usr/share/nginx/html;\n\
-    index index.html;\n\
-    add_header X-Frame-Options "SAMEORIGIN" always;\n\
-    location = /env-config.js {\n\
-        add_header Cache-Control "no-store, no-cache, must-revalidate" always;\n\
-        add_header Pragma "no-cache" always;\n\
-    }\n\
-    location / {\n\
-        try_files $uri $uri/ /index.html;\n\
-    }\n\
-}\n' > /etc/nginx/conf.d/default.conf.template
+# nginx config — serve index.html for all routes (SPA fallback) with security headers
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 # Entrypoint: inject runtime env vars then start nginx
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,25 @@
+server {
+    listen %PORT%;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+
+    # nginx does not inherit server-level add_header in location blocks
+    # that define their own add_header, so repeat security headers here.
+    location = /env-config.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the inline nginx config from the `Dockerfile` `RUN printf ...` block into a dedicated `nginx.conf.template` file, making it easier to read and maintain.
- Adds the following security response headers to all responses:
  - `Content-Security-Policy`: restricts sources for scripts, styles, connections, fonts, and images.
  - `X-Content-Type-Options: nosniff`: prevents MIME-type sniffing attacks.
  - `Referrer-Policy: strict-origin-when-cross-origin`: limits referrer header leakage.
- The existing `X-Frame-Options: SAMEORIGIN` header is preserved.
- The `location = /env-config.js` block repeats all security headers alongside its cache-control headers, working around nginx's known behaviour where location-level `add_header` directives do not inherit server-level ones.

## Test plan
- [ ] Build the Docker image and run the container.
- [ ] `curl -I http://localhost:8080/` — verify `Content-Security-Policy`, `X-Content-Type-Options`, and `Referrer-Policy` are present.
- [ ] `curl -I http://localhost:8080/env-config.js` — verify both cache-control headers and all security headers are present.
- [ ] Confirm the SPA loads correctly (CSP allows `'self'` scripts and styles).

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)