### PR TITLE
fix: validate localStorage shape before use to prevent state corruption (closes #28)

### DIFF
--- a/src/pages/ControllerPage/AudioPanel.tsx
+++ b/src/pages/ControllerPage/AudioPanel.tsx
@@ -1090,10 +1090,26 @@ function loadSections(): SectionState {
   try {
     const raw = localStorage.getItem(SECTIONS_KEY)
     if (raw) {
-      const p = JSON.parse(raw) as Partial<SectionState>
-      return {
-        main: { ...DEFAULT_SECTIONS.main, ...(p.main ?? {}) },
-        aux:  { ...DEFAULT_SECTIONS.aux,  ...(p.aux  ?? {}) },
+      const parsed: unknown = JSON.parse(raw)
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const p = parsed as Record<string, unknown>
+        const main = p.main !== null && typeof p.main === 'object' && !Array.isArray(p.main)
+          ? p.main as Record<string, unknown>
+          : {}
+        const aux = p.aux !== null && typeof p.aux === 'object' && !Array.isArray(p.aux)
+          ? p.aux as Record<string, unknown>
+          : {}
+        return {
+          main: {
+            out:    typeof main.out    === 'boolean' ? main.out    : DEFAULT_SECTIONS.main.out,
+            groups: typeof main.groups === 'boolean' ? main.groups : DEFAULT_SECTIONS.main.groups,
+            in:     typeof main.in     === 'boolean' ? main.in     : DEFAULT_SECTIONS.main.in,
+          },
+          aux: {
+            out: typeof aux.out === 'boolean' ? aux.out : DEFAULT_SECTIONS.aux.out,
+            in:  typeof aux.in  === 'boolean' ? aux.in  : DEFAULT_SECTIONS.aux.in,
+          },
+        }
       }
     }
   } catch {}

--- a/src/pages/ControllerPage/index.tsx
+++ b/src/pages/ControllerPage/index.tsx
@@ -36,13 +36,16 @@ function loadPanels(): Panels {
   try {
     const raw = localStorage.getItem(PANELS_STORAGE_KEY)
     if (raw) {
-      const p = JSON.parse(raw) as Partial<Panels>
-      return {
-        multiviewer: p.multiviewer !== false,
-        controller:  p.controller  !== false,
-        audio:       p.audio       !== false,
-        pgm:         p.pgm         !== false,
-        pip:         p.pip         === true,
+      const parsed: unknown = JSON.parse(raw)
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const p = parsed as Record<string, unknown>
+        return {
+          multiviewer: p.multiviewer !== false,
+          controller:  p.controller  !== false,
+          audio:       p.audio       !== false,
+          pgm:         p.pgm         !== false,
+          pip:         p.pip         === true,
+        }
       }
     }
   } catch {}
@@ -74,9 +77,14 @@ function loadControllerOptions(): ControllerOptions {
   try {
     const raw = localStorage.getItem(CONTROLLER_OPTIONS_KEY)
     if (raw) {
-      const p = JSON.parse(raw) as Partial<ControllerOptions>
-      const vt = Array.isArray(p.visibleTransitions) ? p.visibleTransitions.filter((t) => (ALL_TRANSITIONS as readonly string[]).includes(t)) : []
-      return { visibleTransitions: vt.length > 0 ? vt : DEFAULT_TRANSITIONS }
+      const parsed: unknown = JSON.parse(raw)
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const p = parsed as Record<string, unknown>
+        const vt = Array.isArray(p.visibleTransitions)
+          ? (p.visibleTransitions as unknown[]).filter((t): t is string => typeof t === 'string' && (ALL_TRANSITIONS as readonly string[]).includes(t))
+          : []
+        return { visibleTransitions: vt.length > 0 ? vt : DEFAULT_TRANSITIONS }
+      }
     }
   } catch {}
   return { visibleTransitions: DEFAULT_TRANSITIONS }

--- a/src/pages/PanePage/index.tsx
+++ b/src/pages/PanePage/index.tsx
@@ -295,10 +295,19 @@ export function PanePage() {
   const [controllerOptionsOpen, setControllerOptionsOpen] = useState(false)
   const [visibleTransitions, setVisibleTransitions] = useState<string[]>(() => {
     try {
-      const vt = (JSON.parse(localStorage.getItem(CONTROLLER_OPTIONS_KEY) ?? '{}') as { visibleTransitions?: string[] }).visibleTransitions ?? []
-      const valid = vt.filter((t) => (ALL_TRANSITIONS as readonly string[]).includes(t))
-      return valid.length > 0 ? valid : [...DEFAULT_TRANSITIONS]
-    } catch { return [...DEFAULT_TRANSITIONS] }
+      const raw = localStorage.getItem(CONTROLLER_OPTIONS_KEY)
+      if (raw) {
+        const parsed: unknown = JSON.parse(raw)
+        if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          const p = parsed as Record<string, unknown>
+          const vt = Array.isArray(p.visibleTransitions)
+            ? (p.visibleTransitions as unknown[]).filter((t): t is string => typeof t === 'string' && (ALL_TRANSITIONS as readonly string[]).includes(t))
+            : []
+          if (vt.length > 0) return vt
+        }
+      }
+    } catch {}
+    return [...DEFAULT_TRANSITIONS]
   })
 
   // Default PGM pane to first channel when channels first become available.


### PR DESCRIPTION
## Summary

- Replaces bare `JSON.parse(...) as Partial<T>` casts with validated `unknown` parses across three localStorage read sites
- In `ControllerPage/index.tsx`: `loadPanels()` and `loadControllerOptions()` now verify the parsed value is a non-null, non-array object before accessing properties; `loadControllerOptions` also tightens the `visibleTransitions` filter to use a type-narrowing predicate
- In `PanePage/index.tsx`: the `visibleTransitions` state initializer receives the same treatment
- In `ControllerPage/AudioPanel.tsx`: `loadSections()` validates each nested `main`/`aux` sub-object and checks individual fields are booleans before accepting them, falling back to `DEFAULT_SECTIONS` for any bad value

Any non-object payload (number, string, null, array) or a nested field of the wrong type silently falls back to the application defaults, preventing persistent state corruption from XSS-poisoned localStorage keys.

Closes #28