### PR TITLE
fix: add missing security headers to nginx config in Dockerfile (closes #32)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
     add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' wss:; media-src 'self' blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    location = /env-config.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+    }
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

- Added `X-Content-Type-Options: nosniff` to prevent MIME-type sniffing
- Added `Referrer-Policy: strict-origin-when-cross-origin` to prevent URL leakage to third-party origins
- Added `Content-Security-Policy` restricting sources to `'self'`, with explicit allowances for WebSocket connections (`wss:`), media blobs, and `data:` image sources
- Added `Permissions-Policy` restricting camera, microphone, and geolocation access
- Added a `Cache-Control: no-store` rule for `/env-config.js` to prevent caching of runtime configuration
- `X-Frame-Options: SAMEORIGIN` was already present and is retained

## Why

The Dockerfile's inline nginx heredoc was the only nginx configuration used at runtime (the `nginx.conf.template` in the repo root is never `COPY`'d into the image). Only `X-Frame-Options` was set; the remaining standard security headers were absent, leaving the application exposed to MIME sniffing, referrer leakage, and unrestricted inline script execution. No application logic changes were required — this is a pure nginx configuration fix.

Closes #32