### PR TITLE
fix(security): add missing nginx security headers via nginx.conf.template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,7 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

Replace the inline heredoc in the Dockerfile with `COPY nginx.conf.template` to use the existing template that already contains the proper security headers.

## Changes

- `Dockerfile`: Replaced inline nginx heredoc with `COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template`
- This uses the existing `nginx.conf.template` which already includes `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Cache-Control` headers

Fixes #32