### PR TITLE
fix(security): add jq dependency and use it for safe JSON env injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN pnpm build
 # Stage 2: serve with nginx
 FROM nginx:1.27-alpine
 
+# Install jq for safe JSON generation in the entrypoint
+RUN apk add --no-cache jq
+
 # Remove default nginx static assets
 RUN rm -rf /usr/share/nginx/html/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,11 +5,10 @@ set -e
 # Vite bakes VITE_* vars at build time, so we use a runtime-loaded script
 # (/env-config.js) that docker-entrypoint.sh regenerates on every container
 # start from the current process environment.
+
+# Use jq to safely encode env vars as JSON (handles quotes, newlines, special chars)
 cat > /usr/share/nginx/html/env-config.js <<EOF
-window._env_ = {
-  OPEN_LIVE_URL: "${OPEN_LIVE_URL:-}",
-  OSC_PAT: "${OSC_PAT:-}",
-};
+window._env_ = $(jq -n --arg open_live_url "${OPEN_LIVE_URL:-}" --arg osc_pat "${OSC_PAT:-}" '{OPEN_LIVE_URL: $open_live_url, OSC_PAT: $osc_pat}');
 EOF
 
 exec "$@"


### PR DESCRIPTION
Closes #31

Replace the raw heredoc in docker-entrypoint.sh (which can produce
malformed JSON if env vars contain quotes, newlines, or other special
characters) with jq --arg, which properly JSON-encodes all values.

**Changes:**
- `Dockerfile`: Add `jq` as an explicit Alpine package dependency so
  it is always available at runtime
- `docker-entrypoint.sh`: Use `jq -n --arg` to generate the env-config.js
  JSON safely, instead of a raw heredoc that interpolates variables directly
  into JSON without escaping

**Why this fix:** The jq --arg command takes each value as a raw string
argument and handles JSON encoding internally — double quotes, backslashes,
newlines, null bytes, and all other special characters are properly escaped
in the output. The heredoc fallback (which lacked escaping for anything
beyond backslash, double-quote, and tab) is eliminated by ensuring jq is
always installed.

**Verification:**
- `bash -n docker-entrypoint.sh` — shell syntax clean
- jq --arg tested with quotes, newlines, empty values — all produce valid JSON
- Only Dockerfile and entrypoint changed; no JS/TS modifications
