### PR TITLE
fix: use nginx.conf.template in Dockerfile to apply full security headers (closes #39)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,8 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+# nginx config — includes full security header suite (CSP, nosniff, Referrer-Policy, Cache-Control)
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
Replaces the sparse inline heredoc nginx config in the Dockerfile with a COPY of the existing `nginx.conf.template`. The template already contains the full security header suite (CSP, X-Content-Type-Options, Referrer-Policy) and Cache-Control: no-store for /env-config.js, but was never wired into the Docker build.

## Changes
- `Dockerfile`: replaced 11-line heredoc block with `COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template`

Closes #39