### PR TITLE
fix: remove OSC_ from vite envPrefix to prevent PAT from being baked into bundle (closes #43)

### DIFF
--- a/src/lib/sat.ts
+++ b/src/lib/sat.ts
@@ -1,7 +1,7 @@
 /**
  * OSC Service Access Token (SAT) exchange for the Open Live API.
  *
- * OSC_PAT is baked into the bundle at build time (Docker build arg).
+ * OSC_PAT is injected at container startup via window._env_ (docker-entrypoint.sh).
  * On first API call it is exchanged for a short-lived SAT which is cached
  * and refreshed automatically 5 minutes before expiry.
  *
@@ -29,7 +29,7 @@ function isExpiringSoon(c: SatCache): boolean {
 }
 
 function getPat(): string | undefined {
-  return window._env_?.OSC_PAT || import.meta.env.OSC_PAT || undefined
+  return window._env_?.OSC_PAT || undefined
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { resolve } from 'path'
 
 export default defineConfig({
-  envPrefix: ['OPEN_LIVE_', 'OSC_'],
+  envPrefix: ['OPEN_LIVE_'],
   plugins: [
     tailwindcss(),
     react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { resolve } from 'path'
 
 export default defineConfig({
-  envPrefix: ['OPEN_LIVE_', 'OSC_'],
+  envPrefix: ['OPEN_LIVE_'],
   build: {
     sourcemap: false,
   },


### PR DESCRIPTION
## Summary

- `vite.config.ts`: removes `'OSC_'` from `envPrefix`, so only `OPEN_LIVE_`-prefixed variables are embedded at build time
- `src/lib/sat.ts`: removes the `import.meta.env.OSC_PAT` fallback from `getPat()` — the only supported injection path is `window._env_` (set at container startup by `docker-entrypoint.sh`)

## Why

Vite's `envPrefix` causes any matching shell variable to be statically inlined into the JS bundle. A developer or CI runner with `OSC_PAT` exported would silently bake the PAT into the shipped artifact, exposing it to anyone who can inspect the bundle. The `window._env_` runtime injection path is already the canonical approach (used by the Docker entrypoint), so the build-time fallback was both unnecessary and dangerous.

Closes #43