### PR TITLE
fix: remove data:text/html acceptance from graphic URL and HTML source validation — stored XSS (closes #41)

### DIFF
--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -13,7 +13,7 @@ function timeSince(ts: number): string {
 }
 
 function isValidGraphicUrl(s: string): boolean {
-  if (s.startsWith('data:text/html') || s.startsWith('data:image/')) return true
+  if (s.startsWith('data:image/')) return true
   try { const u = new URL(s); return u.protocol === 'http:' || u.protocol === 'https:' }
   catch { return false }
 }

--- a/src/pages/SetupPage/SourcesPanel.tsx
+++ b/src/pages/SetupPage/SourcesPanel.tsx
@@ -76,9 +76,8 @@ export function SourcesPanel() {
     if (!STREAM_TYPE_HAS_ADDRESS[streamType]) return null
     if (!address.trim()) return 'Address is required'
     if (streamType === 'html') {
-      if (address.startsWith('data:text/html')) return null
       try { const u = new URL(address); if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error() }
-      catch { return 'Must be a valid http:// or https:// URL, or a data:text/html URI' }
+      catch { return 'Must be a valid http:// or https:// URL' }
     } else {
       if (!/^srt:\/\/[^?#]*:\d+/.test(address.trim())) return 'Must be a valid srt:// URI'
     }


### PR DESCRIPTION
## Summary

- `src/pages/SetupPage/GraphicsPanel.tsx`: removes `data:text/html` from the allowed URI schemes in `isValidGraphicUrl()` — only `http:`, `https:`, and `data:image/` are now accepted
- `src/pages/SetupPage/SourcesPanel.tsx`: removes the explicit `data:text/html` short-circuit in `validateAddress()` for html-type sources — address must now be a valid `http://` or `https://` URL

## Why

`isValidGraphicUrl()` explicitly permitted `data:text/html` URIs as DSK graphic overlay URLs. An authenticated operator could register a URL like `data:text/html,<script>...</script>` as a graphic overlay. The URL is stored in CouchDB and when rendered in any browser context (iframe, webview, or future UI feature), the embedded JavaScript executes — a stored XSS vulnerability affecting all operators who load the same production.

`SourcesPanel.tsx` had the same issue for html-type source addresses.

HTML overlay and HTML source pages must now be hosted on a trusted `https://` web server rather than inlined as data URIs. The `data:image/` allowance in `isValidGraphicUrl()` is retained for inline image data, which carries no script-execution risk.

Closes #41