### PR TITLE
fix: add serve.json with security headers for pnpm start deployments (closes #42)

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/env-config.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `serve.json` to the repo root, picked up automatically by the `serve` package when running `pnpm start`
- Sets `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on all responses
- Sets `Cache-Control: no-store, no-cache, must-revalidate` on `/env-config.js` to prevent browsers and CDNs from caching the `OSC_PAT` token injected at startup

## Why

The `pnpm start` path (documented in README as the local quickstart) runs `serve -s dist` with no configuration. Without `serve.json`, the `serve` package sends no security headers, leaving non-Docker deployments without clickjacking protection, MIME-type sniffing protection, or referrer controls. The `OSC_PAT` value written into `/env-config.js` at startup was also cacheable indefinitely.

The Docker path is unaffected — it uses `nginx.conf.template` which already sets these headers.

Closes #42