### PR TITLE
fix: attach SAT token as ?token= query param on controller WebSocket upgrade (closes #38)

### DIFF
--- a/src/hooks/useControllerWs.ts
+++ b/src/hooks/useControllerWs.ts
@@ -3,6 +3,7 @@ import { useProductionStore, type PipZone, type PipConfig, type PipTransforms, t
 import { useProductionsStore } from '@/store/productions.store'
 import { useAudioStore } from '@/store/audio.store'
 import { useToastStore } from '@/store/toast.store'
+import { getApiToken } from '@/lib/sat'
 
 import { BASE } from '@/lib/base'
 const WS_BASE = BASE.replace(/^http/, 'ws')
@@ -107,10 +108,14 @@ export function useControllerWs(productionId: string | null): (msg: OutboundMess
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectCount = 0
 
-    const connect = () => {
+    const connect = async () => {
       if (cancelled) return
 
-      const ws = new WebSocket(`${WS_BASE}/ws/productions/${productionId}/controller`)
+      const token = await getApiToken().catch(() => undefined)
+      const wsUrl = new URL(`${WS_BASE}/ws/productions/${productionId}/controller`)
+      if (token) wsUrl.searchParams.set('token', token)
+
+      const ws = new WebSocket(wsUrl.toString())
       wsRef.current = ws
 
       ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary

- Imports `getApiToken` from `@/lib/sat` in `useControllerWs.ts`
- Makes the `connect()` closure `async` so it can await the SAT token before opening the WebSocket
- Appends `?token=<SAT>` to the WebSocket URL when a token is available, ensuring the token travels with the upgrade request where cookies cannot be relied upon

**Backend note**: On OSC deployments the SAT cookie already covers WS authentication via the OSC reverse proxy; the `?token=` parameter is a complementary fallback. For self-hosted deployments with `API_KEY` configured on the backend, a complementary backend change is needed to also validate the WS `?token=` parameter against `config.apiKey` (the `/ws/` path is currently exempt from the `onRequest` auth hook in `server.ts`). That backend fix is tracked as a follow-up in the `open-live` repository.

## Test plan

- [ ] On OSC: verify WebSocket URL in browser DevTools network tab includes `?token=<jwt>`
- [ ] Confirm reconnect still works after token expiry (getApiToken refreshes automatically)
- [ ] Confirm no regression in tally sync / audio metering on OSC

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)