### PR TITLE
fix: validate pane and productionId URL params at runtime (closes #44)

### DIFF
--- a/src/pages/PanePage/index.tsx
+++ b/src/pages/PanePage/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
-import { useParams, useSearchParams } from 'react-router'
+import { Navigate, useParams, useSearchParams } from 'react-router'
 import { useWebRTC } from '@/hooks/useWebRTC'
 import { useControllerWs } from '@/hooks/useControllerWs'
 import { useProductionStore } from '@/store/production.store'
@@ -177,6 +177,8 @@ const TRANSITION_LABELS: Record<string, string> = {
 }
 
 type Pane = 'multiviewer' | 'controller' | 'audio' | 'pgm' | 'pip'
+const VALID_PANES: readonly Pane[] = ['multiviewer', 'controller', 'audio', 'pgm', 'pip']
+const PRODUCTION_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/
 
 // ─── PGM confidence monitor ───────────────────────────────────────────────────
 
@@ -221,9 +223,11 @@ function AudioPaneFullscreen({ send, numAuxBuses, numGroups, showEbuMain, auxBus
 }
 
 export function PanePage() {
-  const { pane } = useParams<{ pane: Pane }>()
+  const { pane: rawPane } = useParams<{ pane: string }>()
   const [searchParams] = useSearchParams()
-  const productionId = searchParams.get('production')
+  const pane: Pane | null = VALID_PANES.includes(rawPane as Pane) ? (rawPane as Pane) : null
+  const rawProductionId = searchParams.get('production')
+  const productionId = rawProductionId !== null && !PRODUCTION_ID_RE.test(rawProductionId) ? null : rawProductionId
 
   // No Shell in this route — bootstrap all store data ourselves
   const fetchProductions = useProductionsStore((s) => s.fetchAll)
@@ -359,6 +363,9 @@ export function PanePage() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
+
+  if (!pane) return <Navigate to="/" replace />
+  if (rawProductionId !== null && productionId === null) return <Navigate to="/" replace />
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Adds an allowlist check (`VALID_PANES`) for the `pane` path parameter to prevent unrecognised pane strings from reaching WebSocket routing logic
- Adds a regex check (`PRODUCTION_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/`) for the `productionId` query parameter to reject path-traversal characters before the value is interpolated into WebSocket URLs
- Both guards run after all hooks (satisfying React's rules of hooks); invalid values redirect to `/` via `<Navigate replace />`

## Test plan

- [ ] Navigate to `/pane/controller?production=my-prod-id` — page loads normally
- [ ] Navigate to `/pane/evil?production=my-prod-id` — redirects to `/`
- [ ] Navigate to `/pane/controller?production=../../../etc` — redirects to `/`
- [ ] Navigate to `/pane/controller` (no production param) — page loads (no redirect; null productionId handled gracefully)

Closes #44