### PR TITLE
fix: lock CSP connect-src to backend origin at runtime (closes #40)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,7 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 
@@ -41,4 +30,4 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["/bin/sh", "-c", "sed s/%PORT%/$PORT/ /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,4 +32,17 @@ else
     > /usr/share/nginx/html/env-config.js
 fi
 
+# Generate nginx config, locking CSP connect-src to the backend origin when known.
+# Falling back to broad wildcards only when OPEN_LIVE_URL is not set.
+PORT="${PORT:-8080}"
+if [ -n "$OPEN_LIVE_URL" ]; then
+  BACKEND_WSS="$(printf '%s' "$OPEN_LIVE_URL" | sed 's|^https:|wss:|; s|^http:|ws:|')"
+  CSP_CONNECT_SRC="'self' $OPEN_LIVE_URL $BACKEND_WSS https://token.svc.prod.osaas.io"
+else
+  CSP_CONNECT_SRC="'self' wss: https:"
+fi
+sed -e "s|%PORT%|$PORT|g" \
+    -e "s|%CSP_CONNECT_SRC%|$CSP_CONNECT_SRC|g" \
+  /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
 exec "$@"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -6,7 +6,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -16,7 +16,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+        add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary

- Replaces the bare `wss:` wildcard in `nginx.conf.template`'s `connect-src` with a `%CSP_CONNECT_SRC%` placeholder
- `docker-entrypoint.sh` now derives the WebSocket origin from `OPEN_LIVE_URL` at container start and substitutes it (together with `%PORT%`) when writing `/etc/nginx/conf.d/default.conf`; falls back to the broad wildcard only when `OPEN_LIVE_URL` is unset
- Wires `nginx.conf.template` into the `Dockerfile` via `COPY`, replacing the sparse inline heredoc that had only `X-Frame-Options` — the full security header suite (CSP, `X-Content-Type-Options`, `Referrer-Policy`) is now active in every Docker build
- Simplifies `CMD` to `["nginx", "-g", "daemon off;"]` — the entrypoint already calls `exec "$@"`, so no shell wrapper is needed

## Test plan

- [ ] Build the Docker image with `OPEN_LIVE_URL=https://api.example.com` set at runtime — verify `Content-Security-Policy` header contains `connect-src 'self' https://api.example.com wss://api.example.com https://token.svc.prod.osaas.io` and NOT a bare `wss:`
- [ ] Build and run without `OPEN_LIVE_URL` — verify CSP falls back to `connect-src 'self' wss: https:`
- [ ] Verify `/env-config.js` still has `Cache-Control: no-store`
- [ ] Verify all other security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) are present

Closes #40