### PR TITLE
fix: add security headers to serve-based deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ Sources and productions are polled from the backend every 5 seconds. All changes
 
 The app is deployed on [Open Source Cloud](https://www.osaas.io) using the `pnpm start` script. The `VITE_API_URL` parameter must be set in the app's OSC parameter store before deployment so Vite can bake the correct backend URL into the bundle at build time.
 
+> **The Docker image (`Dockerfile`) is the canonical production serving path.** It uses nginx with security headers (including `X-Frame-Options`) enabled by default. The `pnpm start` path exists for local preview and quickstart development; for production use, prefer the Docker image.
+
 Set `CORS_ORIGIN` on the backend to this app's OSC URL and restart the backend whenever this app's URL changes.

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/env-config.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add a `serve.json` configuration file for the `serve` package used by `pnpm start`, setting the following security headers on all routes:

| Header | Value | Purpose |
|---|---|---|
| `X-Frame-Options` | `SAMEORIGIN` | Prevents clickjacking |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME type sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer information leakage |

Additionally, `/env-config.js` (the OSC deployment runtime config which may contain `OSC_PAT`) gets `Cache-Control: no-store, no-cache, must-revalidate` to prevent caching of the environment variable bundle.

The Docker image (`Dockerfile`) already serves with correct security headers via nginx — this closes the gap for the `pnpm start` / `serve` path used by OSC deployments and local quickstarts.

Also updates README.md to clarify that the Docker image is the canonical production serving path.

Closes #42