### PR TITLE
fix(security): serve.json headers for pnpm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ pnpm typecheck
 pnpm build
 
 # Serve the production build (OSC deployment — respects $PORT, defaults to 8080)
+# Adds security headers via serve.json. For production, prefer the Docker image when available.
 pnpm start
 
 # Preview the production build locally

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/env-config.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add serve.json security headers; note Docker as preferred production path. Fixes #42.