### PR TITLE
fix(security): Permissions-Policy for microphone/HID

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -7,6 +7,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    # Intercom uses mic; Stream Deck uses HID — keep same-origin only; block camera/usb.
+    add_header Permissions-Policy "camera=(), microphone=(self), hid=(self), usb=()" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -17,6 +19,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+        add_header Permissions-Policy "camera=(), microphone=(self), hid=(self), usb=()" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
Closes #55.

Add `Permissions-Policy: camera=(), microphone=(self), hid=(self), usb=()` so camera/USB stay off and intercom mic + Stream Deck HID stay same-origin only.

## Changes
- `nginx.conf.template` — server block + `/env-config.js` location (nginx does not inherit `add_header`)

## Test plan
- [ ] Response headers include Permissions-Policy on HTML and env-config.js
- [ ] Intercom mic still works same-origin