### PR TITLE
fix(security): explicitly disable production source maps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       '@': resolve(__dirname, 'src'),
     },
   },
+  build: {
+    // Explicit: never ship TS source maps in production (closes #56).
+    sourcemap: false,
+  },
   server: {
     proxy: {
       '/api/v1': 'http://localhost:8080',


### PR DESCRIPTION
## Summary
Closes #56.

Set `build.sourcemap: false` explicitly so production builds never ship TypeScript source maps if Vite defaults or build flags change.

## Test plan
- [ ] `pnpm build` does not emit `.map` files under `dist`