### PR TITLE
fix(security): CSP media-src + frame-src/object-src none

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -6,7 +6,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -16,7 +16,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
Closes #57.

Extend Content-Security-Policy:
- `media-src 'self' blob:` — WebRTC MediaStream blob URLs
- `frame-src 'none'` — no iframes
- `object-src 'none'` — no object/embed (defence vs SVG/embed vectors)

Applied on server block and `/env-config.js` location (nginx non-inherit).

## Test plan
- [ ] CSP header includes the three new directives
- [ ] WebRTC/media still plays (blob: allowed)
- [ ] iframe embed of external origin blocked