### PR TITLE
fix(security): reject data:text/html graphic and HTML source URLs

### DIFF
--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -12,10 +12,16 @@ function timeSince(ts: number): string {
   return `${Math.floor(secs / 60)}m ago`
 }
 
+/** #41: no data:text/html (stored XSS). Allow http(s) and image data URIs only. */
 function isValidGraphicUrl(s: string): boolean {
-  if (s.startsWith('data:text/html') || s.startsWith('data:image/')) return true
-  try { const u = new URL(s); return u.protocol === 'http:' || u.protocol === 'https:' }
-  catch { return false }
+  if (s.startsWith('data:image/')) return true
+  if (s.startsWith('data:')) return false
+  try {
+    const u = new URL(s)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 export function GraphicsPanel() {
@@ -46,7 +52,7 @@ export function GraphicsPanel() {
 
   function handleAdd() {
     if (!newName.trim() || !newUrl.trim()) return
-    if (!isValidGraphicUrl(newUrl.trim())) { setAddUrlError('Must be a valid http/https URL or data URI'); return }
+    if (!isValidGraphicUrl(newUrl.trim())) { setAddUrlError('Must be a valid http/https URL or data:image URI'); return }
     void addGraphic({ name: newName.trim(), url: newUrl.trim() })
     setNewName('')
     setNewUrl('')
@@ -56,7 +62,7 @@ export function GraphicsPanel() {
 
   function handleEdit() {
     if (!editTarget || !editTarget.name.trim() || !editTarget.url.trim()) return
-    if (!isValidGraphicUrl(editTarget.url.trim())) { setEditUrlError('Must be a valid http/https URL or data URI'); return }
+    if (!isValidGraphicUrl(editTarget.url.trim())) { setEditUrlError('Must be a valid http/https URL or data:image URI'); return }
     void updateGraphic(editTarget.id, { name: editTarget.name.trim(), url: editTarget.url.trim() })
     setEditUrlError(null)
     setEditTarget(null)

--- a/src/pages/SetupPage/SourcesPanel.tsx
+++ b/src/pages/SetupPage/SourcesPanel.tsx
@@ -76,9 +76,13 @@ export function SourcesPanel() {
     if (!STREAM_TYPE_HAS_ADDRESS[streamType]) return null
     if (!address.trim()) return 'Address is required'
     if (streamType === 'html') {
-      if (address.startsWith('data:text/html')) return null
-      try { const u = new URL(address); if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error() }
-      catch { return 'Must be a valid http:// or https:// URL, or a data:text/html URI' }
+      // #41: reject data:text/html (stored XSS); http(s) only for HTML sources
+      try {
+        const u = new URL(address)
+        if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error()
+      } catch {
+        return 'Must be a valid http:// or https:// URL'
+      }
     } else {
       if (!/^srt:\/\/[^?#]*:\d+/.test(address.trim())) return 'Must be a valid srt:// URI'
     }


### PR DESCRIPTION
## Summary
Closes #41.

- Graphics: block `data:text/html`; allow `http(s)` and `data:image/`
- HTML sources: `http(s)` only

## Test plan
- [ ] Add graphic with data:text/html → validation error
- [ ] Add graphic with https URL → ok
- [ ] HTML source data:text/html → error