### PR TITLE
fix(security): restrict graphic data URIs to safe rasters

### DIFF
--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -12,10 +12,24 @@ function timeSince(ts: number): string {
   return `${Math.floor(secs / 60)}m ago`
 }
 
+/** Safe raster data URIs only — reject data:text/html (#41) and data:image/svg+xml (#54). */
+const SAFE_DATA_PREFIXES = [
+  'data:image/png',
+  'data:image/jpeg',
+  'data:image/jpg',
+  'data:image/gif',
+  'data:image/webp',
+] as const
+
 function isValidGraphicUrl(s: string): boolean {
-  if (s.startsWith('data:text/html') || s.startsWith('data:image/')) return true
-  try { const u = new URL(s); return u.protocol === 'http:' || u.protocol === 'https:' }
-  catch { return false }
+  if (SAFE_DATA_PREFIXES.some((p) => s.startsWith(p))) return true
+  if (s.startsWith('data:')) return false
+  try {
+    const u = new URL(s)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 export function GraphicsPanel() {

--- a/src/pages/SetupPage/SourcesPanel.tsx
+++ b/src/pages/SetupPage/SourcesPanel.tsx
@@ -76,9 +76,12 @@ export function SourcesPanel() {
     if (!STREAM_TYPE_HAS_ADDRESS[streamType]) return null
     if (!address.trim()) return 'Address is required'
     if (streamType === 'html') {
-      if (address.startsWith('data:text/html')) return null
-      try { const u = new URL(address); if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error() }
-      catch { return 'Must be a valid http:// or https:// URL, or a data:text/html URI' }
+      try {
+        const u = new URL(address)
+        if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error()
+      } catch {
+        return 'Must be a valid http:// or https:// URL'
+      }
     } else {
       if (!/^srt:\/\/[^?#]*:\d+/.test(address.trim())) return 'Must be a valid srt:// URI'
     }


### PR DESCRIPTION
## Summary
Closes #54 (and covers #41).

- Allow only `data:image/png|jpeg|jpg|gif|webp`
- Reject `data:image/svg+xml`, `data:text/html`, other `data:`
- HTML sources: `http(s)` only

## Test plan
- [ ] Graphic `data:image/svg+xml,...` → rejected
- [ ] Graphic `data:image/png;base64,...` → accepted
- [ ] Graphic `https://...` → accepted