### PR TITLE
fix(security): stop baking OSC_PAT into the Vite bundle

### DIFF
--- a/src/lib/sat.ts
+++ b/src/lib/sat.ts
@@ -1,7 +1,8 @@
 /**
  * OSC Service Access Token (SAT) exchange for the Open Live API.
  *
- * OSC_PAT is baked into the bundle at build time (Docker build arg).
+ * OSC_PAT must come from runtime config (window._env_ / Docker entrypoint),
+ * never from Vite import.meta.env (#43 — secrets must not ship in static JS).
  * On first API call it is exchanged for a short-lived SAT which is cached
  * and refreshed automatically 5 minutes before expiry.
  *
@@ -29,7 +30,7 @@ function isExpiringSoon(c: SatCache): boolean {
 }
 
 function getPat(): string | undefined {
-  return window._env_?.OSC_PAT || import.meta.env.OSC_PAT || undefined
+  return window._env_?.OSC_PAT || undefined
 }
 
 /**

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
   readonly OPEN_LIVE_URL: string
-  readonly OSC_PAT: string
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { resolve } from 'path'
 
 export default defineConfig({
-  envPrefix: ['OPEN_LIVE_', 'OSC_'],
+  // #43: do not use OSC_ prefix — OSC_PAT would bake into the public JS bundle.
+  envPrefix: ['OPEN_LIVE_'],
   plugins: [
     tailwindcss(),
     react(),


### PR DESCRIPTION
## Summary
Closes #43.

- `envPrefix` is `OPEN_LIVE_` only (no `OSC_`)
- `getPat()` uses `window._env_?.OSC_PAT` only
- Remove `OSC_PAT` from `ImportMetaEnv`

## Test plan
- [ ] `OSC_PAT=secret pnpm build` then grep dist — secret not present
- [ ] Runtime `window._env_.OSC_PAT` still works when injected