### PR TITLE
fix(security): use nginx.conf.template in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,8 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+# #39: use full security-header template (not sparse inline heredoc)
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
Closes #39.

Docker image now serves via `nginx.conf.template` (full security headers) instead of a minimal inline heredoc.

## Test plan
- [ ] `docker build` succeeds
- [ ] Response headers include CSP, X-Content-Type-Options, Referrer-Policy
- [ ] `/env-config.js` has Cache-Control no-store