### PR TITLE
fix(security): escape newlines in entrypoint JSON fallback

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,12 +19,14 @@ if command -v jq > /dev/null 2>&1; then
       '{OPEN_LIVE_URL: $u, OSC_PAT: $p}')" \
     > /usr/share/nginx/html/env-config.js
 else
-  # Fallback: manual JSON encoding (escape backslash, double-quote, control chars)
+  # Fallback: manual JSON encoding when jq is missing (#31: escape newlines/CR)
   escape_json() {
     printf '%s' "$1" | sed \
       -e 's/\\/\\\\/g' \
       -e 's/"/\\"/g' \
-      -e 's/	/\\t/g'
+      -e 's/	/\\t/g' \
+      -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' \
+      -e 's/\r/\\r/g'
   }
   U="$(escape_json "$OPEN_LIVE_URL")"
   P="$(escape_json "$OSC_PAT")"


### PR DESCRIPTION
## Summary
Closes #31.

`escape_json` fallback escapes `\n` and `\r` when jq is missing.

## Test plan
- [ ] Without jq, newline in OPEN_LIVE_URL does not break env-config.js into raw JS