### PR TITLE
Add serve.json with security headers for non-Docker deployments

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/env-config.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #42

Adds a serve.json configuration file that adds security headers when running via pnpm start (serve -s dist):

- X-Frame-Options: SAMEORIGIN
- X-Content-Type-Options: nosniff
- Referrer-Policy: strict-origin-when-cross-origin
- Cache-Control: no-store on /env-config.js (contains OSC_PAT)