### PR TITLE
fix: use nginx.conf.template with security headers in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,9 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+
+# nginx config — serve index.html for all routes (SPA fallback) with security headers
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Description

Replaces the inline heredoc nginx config in the Dockerfile with a `COPY` of the existing `nginx.conf.template`, which includes proper security headers that were missing from the inline version.

The `nginx.conf.template` file already existed in the repo with a full set of security headers (CSP, X-Content-Type-Options, Referrer-Policy) — it just wasn't being used in the Docker build.

## Changes

- `Dockerfile`: removed inline nginx config heredoc, replaced with `COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template`

## Related Issues

- Fixes #42 — Security headers missing in containerized deployments
- Fixes #39 — Docker bakes inline nginx config instead of using template