### PR TITLE
fix(security): prevent stored XSS by rejecting data:text/html URIs

### DIFF
--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -13,7 +13,7 @@ function timeSince(ts: number): string {
 }
 
 function isValidGraphicUrl(s: string): boolean {
-  if (s.startsWith('data:text/html') || s.startsWith('data:image/')) return true
+  if (s.startsWith('data:image/')) return true
   try { const u = new URL(s); return u.protocol === 'http:' || u.protocol === 'https:' }
   catch { return false }
 }

--- a/src/pages/SetupPage/SourcesPanel.tsx
+++ b/src/pages/SetupPage/SourcesPanel.tsx
@@ -76,9 +76,8 @@ export function SourcesPanel() {
     if (!STREAM_TYPE_HAS_ADDRESS[streamType]) return null
     if (!address.trim()) return 'Address is required'
     if (streamType === 'html') {
-      if (address.startsWith('data:text/html')) return null
       try { const u = new URL(address); if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error() }
-      catch { return 'Must be a valid http:// or https:// URL, or a data:text/html URI' }
+      catch { return 'Must be a valid http:// or https:// URL' }
     } else {
       if (!/^srt:\/\/[^?#]*:\d+/.test(address.trim())) return 'Must be a valid srt:// URI'
     }


### PR DESCRIPTION
## Summary

Mitigates a Stored XSS security vulnerability by rejecting `data:text/html` URIs in URL input fields (closes #41).

## Changes
- Modified `isValidGraphicUrl` in `src/pages/SetupPage/GraphicsPanel.tsx` to only accept `data:image/` schemas, `http:` and `https:` protocols.
- Modified `validateAddress` for `html` streamType in `src/pages/SetupPage/SourcesPanel.tsx` to only accept `http:` and `https:` protocols, rejecting inline html payloads.

This ensures malicious HTML/JS payloads cannot be stored in the database via overlay URL forms.

Signed-off-by: emreumar <emreumar@users.noreply.github.com>