### PR TITLE
fix(infra): add security headers to serve.json configuration

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,18 @@
+{
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/env-config.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds security headers to static files served via the `serve` package (closes #42).

## Changes
- Created a `serve.json` configuration file in the project root.
- Added security headers (`X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`) for all static assets (`**`).
- Explicitly disabled caching (`Cache-Control: no-store, no-cache, must-revalidate`) for `/env-config.js` to prevent exposure of injected runtime secrets (like `OSC_PAT`).

Signed-off-by: emreumar <emreumar@users.noreply.github.com>