### PR TITLE
[SECURITY][LOW] fix: remove OSC_PAT from Vite envPrefix to prevent secret leak at build time

### DIFF
--- a/src/lib/sat.ts
+++ b/src/lib/sat.ts
@@ -29,7 +29,7 @@ function isExpiringSoon(c: SatCache): boolean {
 }
 
 function getPat(): string | undefined {
-  return window._env_?.OSC_PAT || import.meta.env.OSC_PAT || undefined
+  return window._env_?.OSC_PAT || undefined
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { resolve } from 'path'
 
 export default defineConfig({
-  envPrefix: ['OPEN_LIVE_', 'OSC_'],
+  envPrefix: ['OPEN_LIVE_'],
   plugins: [
     tailwindcss(),
     react(),


### PR DESCRIPTION
## Description

Removes `'OSC_'` from Vite's `envPrefix` so that build-time environment variables prefixed with `OSC_` (including `OSC_PAT`) are no longer automatically captured and baked into the JavaScript bundle.

The `import.meta.env.OSC_PAT ||` fallback in `sat.ts` `getPat()` is also removed since runtime injection via `window._env_.OSC_PAT` is the only supported path.

**Before:** Both `OPEN_LIVE_` and `OSC_` prefixed env vars were captured by Vite at build time and baked into the bundle.
**After:** Only `OPEN_LIVE_` prefixed vars are captured. `OSC_PAT` must be provided at runtime via `window._env_`.

## Related

Fixes #43