### PR TITLE
fix: bump react-router to ^7.15.1 to address CVE-2026-40181 and related CVEs (closes #82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "immer": "^10.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.5.1",
+    "react-router": "^7.15.1",
     "serve": "^14.2.6",
     "tailwind-merge": "^3.2.0",
     "zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
       react-router:
-        specifier: ^7.5.1
-        version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.15.1
+        version: 7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       serve:
         specifier: ^14.2.6
         version: 14.2.6
@@ -1355,8 +1355,8 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -2719,7 +2719,7 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4


### PR DESCRIPTION
## Summary

- Bumps `react-router` from `^7.5.1` to `^7.15.1` (resolved to `7.18.1` by pnpm)
- Resolves open redirect (CVE-2026-40181), CSRF via PUT/PATCH/DELETE, and path DoS vulnerabilities
- The Framework Mode RCE (CVE-2026-42211) does not apply — this project uses Declarative/Browser Mode

## Test plan

- [ ] Run `pnpm install` and verify `pnpm-lock.yaml` resolves `react-router` to `≥7.15.1`
- [ ] Run `pnpm audit` to confirm react-router advisories are resolved
- [ ] Verify the studio UI builds (`pnpm build`) without errors
- [ ] Smoke-test navigation between `/live`, `/monitor`, and other routes

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)