### PR TITLE
fix(build): explicitly disable production source maps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { resolve } from 'path'
 
 export default defineConfig({
   envPrefix: ['OPEN_LIVE_', 'OSC_'],
+  build: {
+    sourcemap: false,
+  },
   plugins: [
     tailwindcss(),
     react(),


### PR DESCRIPTION
## Summary
- Explicitly set build.sourcemap: false in vite.config.ts so production builds never emit TypeScript source maps, regardless of Vite defaults.

## Changes
- open-live-studio: add build.sourcemap:false to the Vite config.

## Test Plan
- [ ] tsc --noEmit passes
- [ ] build passes, no .map files emitted

## Checklist
- [x] Code-quality checks passed

Closes #56

🤖 Generated with Claude Code