### PR TITLE
chore: add CI workflow (lint, typecheck, build) on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run build


### PR DESCRIPTION
Part of addressing [Eyevinn/agent-team-open-live#4](https://github.com/Eyevinn/agent-team-open-live/issues/4) — this repo had exactly one GitHub Actions workflow (`sync-fork.yml`, a manual deploy trigger) and nothing ran on pull requests. `main` also has no branch protection (tracked separately — that's a settings change, not a code change, so it's not part of this PR).

## What this adds
`.github/workflows/ci.yml`: on every PR and push to `main`, runs `pnpm install --frozen-lockfile`, then `lint`, `typecheck`, and `build`.

No test step — this repo has no test runner installed and no `*.test.*`/`*.spec.*` files, so there's genuinely nothing to run yet. `code-quality.md` (in `agent-team-open-live`) now says this explicitly rather than assuming a test suite that doesn't exist.

## Known gap
`pnpm run lint` currently fails with **39 errors / 14 warnings** across 21 files — it's apparently never been enforced. Filed as #92 with the full output and a few items worth a closer look (a `no-constant-binary-expression` that looks like an actual logic bug, not just dead code) rather than attempting a 21-file mechanical cleanup unreviewed inside this PR. This CI workflow will start **red on lint** until #92 is cleared — flagging that up front so it's not a surprise.

## Test plan
- [x] `pnpm run lint` — fails as expected (39/14, tracked in #92)
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)