### PR TITLE
fix(docker): require jq and drop unsafe escape_json fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN pnpm build
 # Stage 2: serve with nginx
 FROM nginx:1.27-alpine
 
+# jq is required by docker-entrypoint.sh to safely serialize runtime env vars
+RUN apk add --no-cache jq
+
 # Remove default nginx static assets
 RUN rm -rf /usr/share/nginx/html/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,31 +6,23 @@ set -e
 # env var values — the heredoc approach is vulnerable to shell injection if
 # the values contain quotes or braces.
 #
-# nginx:alpine ships with jq available via the base image.
-# If jq is not present, fall back to printf with manual hex-escaping.
+# jq is a required dependency (installed in the Dockerfile). We fail closed
+# if it is missing rather than falling back to unsafe manual escaping, which
+# previously missed newlines/CR/null and allowed JS injection.
 
 OPEN_LIVE_URL="${OPEN_LIVE_URL:-}"
 OSC_PAT="${OSC_PAT:-}"
 
-if command -v jq > /dev/null 2>&1; then
-  # Safe: jq --arg passes values as literals, never interpolated
-  printf 'window._env_ = %s;\n' \
-    "$(jq -n --arg u "$OPEN_LIVE_URL" --arg p "$OSC_PAT" \
-      '{OPEN_LIVE_URL: $u, OSC_PAT: $p}')" \
-    > /usr/share/nginx/html/env-config.js
-else
-  # Fallback: manual JSON encoding (escape backslash, double-quote, control chars)
-  escape_json() {
-    printf '%s' "$1" | sed \
-      -e 's/\\/\\\\/g' \
-      -e 's/"/\\"/g' \
-      -e 's/	/\\t/g'
-  }
-  U="$(escape_json "$OPEN_LIVE_URL")"
-  P="$(escape_json "$OSC_PAT")"
-  printf 'window._env_ = {"OPEN_LIVE_URL":"%s","OSC_PAT":"%s"};\n' "$U" "$P" \
-    > /usr/share/nginx/html/env-config.js
+if ! command -v jq > /dev/null 2>&1; then
+  echo "docker-entrypoint.sh: fatal: jq is required but not installed" >&2
+  exit 1
 fi
+
+# Safe: jq --arg passes values as literals, never interpolated
+printf 'window._env_ = %s;\n' \
+  "$(jq -n --arg u "$OPEN_LIVE_URL" --arg p "$OSC_PAT" \
+    '{OPEN_LIVE_URL: $u, OSC_PAT: $p}')" \
+  > /usr/share/nginx/html/env-config.js
 
 # Render the nginx config from the template, tightening the CSP connect-src so
 # the SPA can only reach the origins it actually talks to:


### PR DESCRIPTION
## Summary

Fixes a MEDIUM security issue (#31) in `docker-entrypoint.sh`. The fallback
`escape_json()` used when `jq` was absent only escaped backslash, double-quote,
and tab — but NOT newlines, carriage returns, or null bytes. A value containing
a newline could inject raw JS into the generated `env-config.js`.

**Remediation (Option A):**
- `Dockerfile`: explicitly install `jq` on the runtime nginx image (`RUN apk add --no-cache jq`).
- `docker-entrypoint.sh`: remove the unsafe manual `escape_json` fallback. The
  script now fails closed (`exit 1`) if `jq` is missing and always uses the safe
  `jq --arg` path.

## Test Plan

- [x] `bash -n docker-entrypoint.sh` — passes
- [x] `sh -n docker-entrypoint.sh` — passes
- [ ] `docker build .` — not run (Docker not available in this environment)

Docker-only change; no TypeScript touched, so no pnpm build required.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)