### PR TITLE
fix(csp): add media-src, frame-src, and object-src directives

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -6,7 +6,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -16,7 +16,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+        add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- Adds `media-src 'self' blob:`, `frame-src 'none'`, and `object-src 'none'` to the Content-Security-Policy header in `nginx.conf.template` for defense-in-depth.
- `media-src 'self' blob:` permits WebRTC MediaStream blob: URLs; `frame-src`/`object-src` set to `'none'`.
- Applied to both the server-level and `/env-config.js` location-level CSP headers so they stay consistent.
- All pre-existing directives (`default-src`, `connect-src`, `script-src`, `style-src`, `img-src`, `font-src`) are preserved unchanged; the `always` flag is retained.

## Test plan
- [ ] Verify by inspection: CSP header is a single well-formed quoted string with semicolon-separated directives and a trailing `;`.
- [ ] Confirm no other headers (e.g. Permissions-Policy from PR #55) were touched.
- [ ] Optional: `nginx -t` against a rendered config.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)