### PR TITLE
fix(graphics): reject data:image/svg+xml and non-raster data URIs

### DIFF
--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -13,7 +13,12 @@ function timeSince(ts: number): string {
 }
 
 function isValidGraphicUrl(s: string): boolean {
-  if (s.startsWith('data:image/')) return true
+  if (s.startsWith('data:')) {
+    // Only allow safe raster image formats. Reject svg+xml (can carry inline
+    // scripts / SMIL handlers) and text/html to avoid XSS.
+    const safeDataPrefixes = ['data:image/png', 'data:image/jpeg', 'data:image/gif', 'data:image/webp']
+    return safeDataPrefixes.some((p) => s.startsWith(p))
+  }
   try { const u = new URL(s); return u.protocol === 'http:' || u.protocol === 'https:' }
   catch { return false }
 }


### PR DESCRIPTION
## Summary

Fixes a medium-severity XSS vector in the graphics URL validator. `isValidGraphicUrl()` in `src/pages/SetupPage/GraphicsPanel.tsx` accepted any `data:image/` URI (and `data:text/html`). This allowed `data:image/svg+xml`, which can embed inline scripts / SMIL event handlers that execute when rendered in object/embed/iframe contexts.

Closes #54

## Changes

- Restrict `data:` URIs to safe raster formats only: `data:image/png`, `data:image/jpeg`, `data:image/gif`, `data:image/webp`.
- Explicitly reject all other `data:` URIs, including `data:image/svg+xml` and `data:text/html`.
- Preserve existing http/https handling and the rest of the function.

## Test Plan

- `pnpm run lint` — no new lint problems introduced by this change (pre-existing repo-wide errors remain, unchanged).
- `pnpm run typecheck` — passes.
- `pnpm run build` — passes.
- There is no automated test suite in this repo.

## Checklist

- [x] Change scoped to the validator only
- [x] Matches existing code style
- [x] typecheck and build pass
- [x] No new lint issues in the touched file