### PR TITLE
fix(headers): add Permissions-Policy scoping mic and HID to same-origin

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -7,6 +7,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
+    add_header Permissions-Policy "camera=(), microphone=(self), hid=(self), usb=()" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -17,6 +18,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self' blob:; frame-src 'none'; object-src 'none';" always;
+        add_header Permissions-Policy "camera=(), microphone=(self), hid=(self), usb=()" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary

Adds a `Permissions-Policy` response header to `nginx.conf.template` to close issue #55 (Security, Medium). Previously no `Permissions-Policy` was set, so an XSS payload could inherit an already-granted microphone permission (intercom) and embedders could delegate device access (WebHID Stream Deck).

The header scopes powerful features to same-origin and blocks unused ones:

```
add_header Permissions-Policy "camera=(), microphone=(self), hid=(self), usb=()" always;
```

- `microphone=(self)` — allow intercom mic on same-origin only
- `hid=(self)` — allow Stream Deck WebHID on same-origin only
- `camera=()` / `usb=()` — blocked (not used by the app)

It is added in both the `server` block and the `/env-config.js` `location` block, matching the existing pattern documented in the file's comment (nginx does not inherit server-level `add_header` into location blocks that define their own).

## Deliberate design decision: HTTP header only, no meta tag

I intentionally did **not** add a `<meta http-equiv="Permissions-Policy">` fallback to `index.html`. `Permissions-Policy` is only honored as an HTTP response header — browsers ignore it as a meta tag. Adding one would be dead code giving a false sense of protection. The nginx header is the real and sufficient fix, so `index.html` is left unchanged.

## Scope

Only the `Permissions-Policy` header is added. The CSP directive is intentionally untouched (a sibling PR #57 modifies that line).

## Test plan

- [ ] Confirm `curl -I` against a deployed instance returns the `Permissions-Policy` header on both `/` and `/env-config.js`
- [ ] Verify intercom mic and Stream Deck WebHID still work same-origin
- [ ] Verify embedding the app in a cross-origin iframe cannot access mic/HID

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)