### PR TITLE
Fix startup failure in sync-fork.yml: move concurrency to job level

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -19,15 +19,14 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: sync-fork-${{ inputs.environment }}
-  cancel-in-progress: false
-
 jobs:
   sync-fork:
     name: Sync fork (${{ inputs.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: sync-fork-${{ inputs.environment }}
+      cancel-in-progress: false
     steps:
       - name: Validate environment
         run: |


### PR DESCRIPTION
## What broke
Same bug as [Eyevinn/open-live#193](https://github.com/Eyevinn/open-live/pull/193): the workflow-level `concurrency` block in `sync-fork.yml` fails at trigger time with "This run likely failed because of a workflow file issue."

## Root cause
The `inputs` context does not resolve reliably inside a **workflow-level** `concurrency` block for a reusable workflow invoked via `workflow_call` — a known GitHub Actions bug/limitation ([community discussion #35341](https://github.com/orgs/community/discussions/35341)), which reports the exact failure mode: `Unexpected type of value '', expected type: String`.

## Fix
Move the `concurrency` block from the workflow level down to the `sync-fork` job level in `sync-fork.yml`, where `inputs.environment` resolves correctly for both the `workflow_dispatch` and `workflow_call` triggers. No behavior change intended — still one sync-fork run per environment at a time.

Verified with `actionlint` (no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
