### PR TITLE
Fix pre-existing lint errors blocking the CI build-and-lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-lint:

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -16,6 +16,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    // eslint-disable-next-line no-console -- surfaces uncaught render errors for diagnostics
     console.error('[ErrorBoundary] Uncaught render error:', error, info.componentStack)
   }
 

--- a/src/components/ui/MultiviewCell.tsx
+++ b/src/components/ui/MultiviewCell.tsx
@@ -23,6 +23,9 @@ export function MultiviewCell({ source }: MultiviewCellProps) {
       cancelled = true
       setStream((prev) => { prev?.getTracks().forEach((t) => t.stop()); return null })
     }
+    // Depends on primitive fields, not the `source` object reference, which changes on every
+    // unrelated store update (would cause constant stream reconnects).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source.id, source.color, source.name, source.liveCamera])
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 export { BASE } from './base.js'
 import { BASE } from './base.js'
-import { authenticateWithOpenLive, getApiToken, isOnOsc } from './sat.js'
+import { authenticateWithOpenLive, getApiToken } from './sat.js'
 
 // Paths that manage their own error toasts — skip global handler
 const SILENT_PATHS = ['/api/v1/status', '/api/v1/reconnect']

--- a/src/lib/sat.ts
+++ b/src/lib/sat.ts
@@ -95,6 +95,7 @@ export async function authenticateWithOpenLive(): Promise<number> {
       maxAge = Math.max(0, exp - Math.floor(Date.now() / 1000))
     }
   } catch (err) {
+    // eslint-disable-next-line no-console -- surfaces JWT parse failures for diagnostics
     console.error('[sat] Failed to parse SAT JWT for cookie expiry — using 1h default:', err)
   }
 

--- a/src/lib/webrtc.ts
+++ b/src/lib/webrtc.ts
@@ -99,6 +99,7 @@ export class WhepClient {
       this.pc.onicecandidateerror = (e) => {
         // Log only non-sensitive fields — never log e.url (may contain TURN credentials)
         if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console -- dev-only diagnostics, gated by import.meta.env.DEV
           console.warn('[WhepClient] ICE candidate error:', e.errorCode, e.errorText)
         }
       }

--- a/src/lib/whep.ts
+++ b/src/lib/whep.ts
@@ -115,6 +115,7 @@ export async function connectWhep(
     // Best-effort DELETE to release the WHEP server-side session
     if (whepResourceUrl) {
       fetch(whepResourceUrl, { method: 'DELETE' }).catch((err: unknown) => {
+        // eslint-disable-next-line no-console -- surfaces best-effort cleanup failures for diagnostics
         console.warn('[whep] DELETE resource failed (best-effort):', err)
       })
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,9 +7,11 @@ import './index.css'
 // Global safety net for unhandled promise rejections and uncaught errors.
 // These won't crash the tab but will log clearly for debugging.
 window.addEventListener('unhandledrejection', (e) => {
+  // eslint-disable-next-line no-console -- global safety net logs for debugging
   console.error('[global] Unhandled promise rejection:', e.reason)
 })
 window.addEventListener('error', (e) => {
+  // eslint-disable-next-line no-console -- global safety net logs for debugging
   console.error('[global] Uncaught error:', e.error ?? e.message)
 })
 

--- a/src/pages/ControllerPage/AudioPanel.tsx
+++ b/src/pages/ControllerPage/AudioPanel.tsx
@@ -269,7 +269,7 @@ const EMPTY_RECORD: Record<number, boolean> = {}
 
 // ── Channel strip ─────────────────────────────────────────────────────────────
 
-function ChannelStrip({ elementId, label, send, showAfv = false, showPfl = false, showAfl = false, showEbu = false, mixerInput = null, isPgm = false, isPvw = false, busColor = C_MAIN, grpBuses = [] }: {
+function ChannelStrip({ elementId, label, send, showAfv = false, showPfl = false, showAfl = false, showEbu = false, mixerInput = null, isPgm = false, isPvw: _isPvw = false, busColor = C_MAIN, grpBuses = [] }: {
   elementId: string
   label: string
   send: SendFn
@@ -402,7 +402,7 @@ function ChannelStrip({ elementId, label, send, showAfv = false, showPfl = false
       applyPfl(elementId, false)
       send({ type: 'PFL_SET', elementId, enabled: false })
     }
-  }, [afl, pfl, elementId, level, send, applyAfl, applyPfl])
+  }, [afl, pfl, elementId, send, applyAfl, applyPfl])
 
   const { faderContainerH } = useFaderDims()
 
@@ -1112,12 +1112,18 @@ function loadSections(): SectionState {
         }
       }
     }
-  } catch {}
+  } catch {
+    // intentionally empty — malformed/inaccessible localStorage falls back to defaults
+  }
   return DEFAULT_SECTIONS
 }
 
 function saveSections(s: SectionState) {
-  try { localStorage.setItem(SECTIONS_KEY, JSON.stringify(s)) } catch {}
+  try {
+    localStorage.setItem(SECTIONS_KEY, JSON.stringify(s))
+  } catch {
+    // intentionally empty — best-effort persistence; ignore quota/availability errors
+  }
 }
 
 // ── Section bar ───────────────────────────────────────────────────────────────

--- a/src/pages/ControllerPage/PgmPreview.tsx
+++ b/src/pages/ControllerPage/PgmPreview.tsx
@@ -37,7 +37,6 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
   }))
   const [connectionState, setConnectionState] = useState<ViewerConnectionState>('disconnected')
   const [retryCountdown, setRetryCountdown] = useState<number | null>(null)
-  const [retryAttempt, setRetryAttempt] = useState(0)
   const [hasVideo, setHasVideo] = useState(false)
   const clientRef = useRef<WhepClient | null>(null)
 
@@ -95,6 +94,7 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
 
   useEffect(() => {
     if (!whepEndpoint) return
+    const videoEl = videoRef.current
     let cancelled = false
     let countdownTimer: ReturnType<typeof setInterval> | null = null
     let disconnectWatchdog: ReturnType<typeof setTimeout> | null = null
@@ -105,7 +105,6 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
     setAudioTrackCount(0)
     streamRef.current = null
     setHasVideo(false)
-    setRetryAttempt(0)
     setConnectionState('connecting')
 
     const startCountdown = (seconds: number, onDone: () => void) => {
@@ -131,14 +130,12 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
       if (videoRef.current) videoRef.current.srcObject = null
       setHasVideo(false)
       retryCount++
-      setRetryAttempt(retryCount)
       if (retryCount >= MAX_RETRIES) {
         setConnectionState('failed')
         if (disconnectWatchdog) { clearTimeout(disconnectWatchdog); disconnectWatchdog = null }
         disconnectWatchdog = setTimeout(() => {
           if (cancelled) return
           retryCount = MAX_RETRIES - 1
-          setRetryAttempt(retryCount)
           connect()
         }, 30_000)
       } else {
@@ -178,7 +175,6 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
             if (disconnectWatchdog) { clearTimeout(disconnectWatchdog); disconnectWatchdog = null }
             if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; setRetryCountdown(null) }
             retryCount = 0
-            setRetryAttempt(0)
             setConnectionState('connected')
           },
           onDisconnected: () => {
@@ -194,7 +190,6 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
               // Watchdog: fresh reconnect, not a WHEP retry. Reset retryCount so
               // onError gets a full budget for the new connection attempt.
               retryCount = 0
-              setRetryAttempt(0)
               connect()
             }, 5000)
           },
@@ -216,7 +211,6 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
       if (disconnectWatchdog) { clearTimeout(disconnectWatchdog); disconnectWatchdog = null }
       if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; setRetryCountdown(null) }
       retryCount = MAX_RETRIES - 1
-      setRetryAttempt(retryCount)
       connect()
     }
     window.addEventListener('online', handleOnline)
@@ -240,7 +234,7 @@ export const PgmPreview = forwardRef<PgmPreviewHandle, PgmPreviewProps>(function
         void clientRef.current.disconnect()
         clientRef.current = null
       }
-      if (videoRef.current) videoRef.current.srcObject = null
+      if (videoEl) videoEl.srcObject = null
       setConnectionState('disconnected')
     }
   }, [whepEndpoint])

--- a/src/pages/ControllerPage/PipPanel.tsx
+++ b/src/pages/ControllerPage/PipPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
-import { useProductionStore, type PipConfig, type PipZone, type SourceCrop, type PipTransforms, type ZoneBorder } from '@/store/production.store'
+import { useProductionStore, type PipConfig, type SourceCrop, type PipTransforms, type ZoneBorder } from '@/store/production.store'
 import { useProductionsStore } from '@/store/productions.store'
 import { useSourcesStore } from '@/store/sources.store'
 import { cn } from '@/lib/cn'
@@ -57,8 +57,6 @@ function isCropZero(c: SourceCrop): boolean {
   return c.left < 1e-4 && c.top < 1e-4 && c.right < 1e-4 && c.bottom < 1e-4
 }
 
-const CROP_CANVAS_W = 280
-
 type CropRect = { x: number; y: number; w: number; h: number } // in source pixels
 type CropDrag =
   | { kind: 'move';   startRect: CropRect; startMx: number; startMy: number }
@@ -103,7 +101,6 @@ function CropEditor({
   inputIdx,
   transforms,
   onChange,
-  zoneAspect,
   srcW = 1920,
   srcH = 1080,
   headerSlot,
@@ -116,7 +113,6 @@ function CropEditor({
   inputIdx: number
   transforms: PipTransforms
   onChange: (transforms: PipTransforms) => void
-  zoneAspect: number
   srcW?: number
   srcH?: number
   headerSlot?: React.ReactNode
@@ -444,7 +440,7 @@ function CropEditor({
 }
 
 export function PipPanel({ onApply, className }: PipPanelProps) {
-  const { pgmPip, pvwPip, pips, activeProductionId } = useProductionStore()
+  const { pips, activeProductionId } = useProductionStore()
   const production = useProductionsStore((s) => s.productions.find((p) => p.id === activeProductionId))
   const sources = useSourcesStore((s) => s.sources)
 
@@ -1067,7 +1063,6 @@ export function PipPanel({ onApply, className }: PipPanelProps) {
               inputIdx={cropSourceIdx ?? activeZoneSources[0]!}
               transforms={draft.transforms ?? {}}
               onChange={(transforms) => { markDirty(); setDraft((prev) => ({ ...prev, transforms })) }}
-              zoneAspect={(() => { const r = draft.zones[activeZoneIdx]?.rect; return r ? r.w / r.h : 16 / 9 })()}
               lockAspect={activeZoneSources.length >= 2 ? 16 / 9 : (() => { const r = draft.zones[activeZoneIdx]?.rect; return r ? (r.w * pgmResolution.w) / (r.h * pgmResolution.h) : 16 / 9 })()}
               srcW={activeZoneSources.length >= 2 ? 1920 : (production?.inputResolutions?.[cropSourceIdx ?? activeZoneSources[0]!]?.width ?? 1920)}
               srcH={activeZoneSources.length >= 2 ? 1080 : (production?.inputResolutions?.[cropSourceIdx ?? activeZoneSources[0]!]?.height ?? 1080)}

--- a/src/pages/ControllerPage/ProgramPreview.tsx
+++ b/src/pages/ControllerPage/ProgramPreview.tsx
@@ -1,6 +1,4 @@
 import { useRef, useImperativeHandle, forwardRef, useEffect, useState, useCallback } from 'react'
-
-const MAX_RETRIES = 5
 import { useViewerStore } from '@/store/viewer.store'
 import { VideoTile, type VideoTileHandle } from '@/components/ui/VideoTile'
 import { Badge } from '@/components/ui/Badge'
@@ -20,10 +18,8 @@ interface ProgramPreviewProps {
 
 export const ProgramPreview = forwardRef<ProgramPreviewHandle, ProgramPreviewProps>(
   function ProgramPreview({ noSignal = false, audioOn, onAudioOnChange: _onAudioOnChange, audioTrack, onAudioTrackChange: _onAudioTrackChange }, ref) {
-    const { programStream, connectionState, retryCountdown, retryAttempt, audioTrackCount } = useViewerStore()
+    const { programStream, connectionState, retryCountdown } = useViewerStore()
     const tileRef = useRef<VideoTileHandle>(null)
-    // Single-track: unmute video for direct output. Multi-track: AudioContext handles selection, keep video muted.
-    const videoMuted = !audioOn || audioTrackCount > 1
 
     // hasVideoReady: true only when the video element is actually decoding frames.
     // Resets whenever connectionState leaves 'connected' so NO SIGNAL stays visible

--- a/src/pages/ControllerPage/SourceBus.tsx
+++ b/src/pages/ControllerPage/SourceBus.tsx
@@ -23,6 +23,9 @@ function SourceCell({ sourceId }: { sourceId: string }) {
       cancelled = true
       setStream((prev) => { prev?.getTracks().forEach((t) => t.stop()); return null })
     }
+    // Depends on primitive fields, not the `source` object reference, which changes on every
+    // unrelated store update (would cause constant stream reconnects).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source?.id, source?.color, source?.name, source?.liveCamera])
 
   if (!source) return null

--- a/src/pages/ControllerPage/SourceBusDual.tsx
+++ b/src/pages/ControllerPage/SourceBusDual.tsx
@@ -31,6 +31,9 @@ function SourceCell({
       cancelled = true
       setStream((prev) => { prev?.getTracks().forEach((t) => t.stop()); return null })
     }
+    // Depends on primitive fields, not the `source` object reference, which changes on every
+    // unrelated store update (would cause constant stream reconnects).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source?.id, source?.color, source?.name, source?.liveCamera])
 
   if (!source) return null

--- a/src/pages/ControllerPage/TimerBar.tsx
+++ b/src/pages/ControllerPage/TimerBar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { BASE } from '@/lib/api'
 import { authenticateWithOpenLive, getApiToken } from '@/lib/sat'
-import { useProgramStartMs, getProgramMode, COUNTDOWN_WINDOW_MS } from '@/store/programClock.store'
+import { useProgramStartMs, getProgramMode } from '@/store/programClock.store'
 import { useProductionStore } from '@/store/production.store'
 import { useProductionsStore } from '@/store/productions.store'
 

--- a/src/pages/ControllerPage/TransitionPanel.tsx
+++ b/src/pages/ControllerPage/TransitionPanel.tsx
@@ -85,7 +85,7 @@ export function TransitionPanel({ onCut, onAuto, onFtb, onSelectPvw, onSetOvl, o
   const {
     pgmInput, pvwInput, isFtb,
     transitionType, transitionDurationMs, tBarPosition,
-    setPgm, setTransitionType, setTransitionDuration, setTBarPosition,
+    setTransitionType, setTransitionDuration, setTBarPosition,
     activeProductionId,
   } = useProductionStore()
 

--- a/src/pages/ControllerPage/index.tsx
+++ b/src/pages/ControllerPage/index.tsx
@@ -50,12 +50,18 @@ function loadPanels(): Panels {
         }
       }
     }
-  } catch {}
+  } catch {
+    // intentionally empty — malformed/inaccessible localStorage falls back to defaults
+  }
   return { multiviewer: true, controller: true, audio: true, pgm: true, pip: false, fx: false }
 }
 
 function savePanels(panels: Panels) {
-  try { localStorage.setItem(PANELS_STORAGE_KEY, JSON.stringify(panels)) } catch {}
+  try {
+    localStorage.setItem(PANELS_STORAGE_KEY, JSON.stringify(panels))
+  } catch {
+    // intentionally empty — best-effort persistence; ignore quota/availability errors
+  }
 }
 
 // ─── Panel options persistence ────────────────────────────────────────────────
@@ -76,6 +82,9 @@ const DEFAULT_TRANSITIONS = ['fade', 'slide_left', 'slide_right']
 
 const CONTROLLER_OPTIONS_KEY = 'ol-studio-controller-options'
 
+// Macros panel is deliberately hidden (implementation preserved in code, not wired into the UI yet).
+const MACROS_ENABLED = false
+
 type ControllerOptions = { visibleTransitions: string[] }
 
 function loadControllerOptions(): ControllerOptions {
@@ -91,7 +100,9 @@ function loadControllerOptions(): ControllerOptions {
         return { visibleTransitions: vt.length > 0 ? vt : DEFAULT_TRANSITIONS }
       }
     }
-  } catch {}
+  } catch {
+    // intentionally empty — malformed/inaccessible localStorage falls back to defaults
+  }
   return { visibleTransitions: DEFAULT_TRANSITIONS }
 }
 
@@ -329,7 +340,11 @@ function ControllerOptionsContent({
     // Commit transitions
     const opts = { ...controllerOptions, visibleTransitions: draftTransitions }
     setControllerOptions(opts)
-    try { localStorage.setItem(CONTROLLER_OPTIONS_KEY, JSON.stringify(opts)) } catch {}
+    try {
+      localStorage.setItem(CONTROLLER_OPTIONS_KEY, JSON.stringify(opts))
+    } catch {
+      // intentionally empty — best-effort persistence; ignore quota/availability errors
+    }
 
     // Send changed offsets via WS
     for (const { mixerInput } of assignments) {
@@ -460,7 +475,7 @@ function ControllerOptionsContent({
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export function ControllerPage() {
-  const { cut, auto, ftb, setPvw, pvwInput, pvwPip, pgmPip, pgmInput, pips, setPvwPip, transitionType, transitionDurationMs, activeProductionId, setActiveProduction, afvRampUpMs, afvRampDownMs, dskState, deactivatedExternally, setDeactivatedExternally } = useProductionStore()
+  const { cut, auto, ftb, setPvw, pvwInput, pvwPip, pgmPip, pgmInput, pips, setPvwPip, transitionType, transitionDurationMs, activeProductionId, setActiveProduction, afvRampUpMs, afvRampDownMs, dskState, deactivatedExternally } = useProductionStore()
   const productions = useProductionsStore((s) => s.productions)
   const fetchProductions = useProductionsStore((s) => s.fetchAll)
   const refreshOneProduction = useProductionsStore((s) => s.refreshOne)
@@ -649,7 +664,7 @@ export function ControllerPage() {
         }
       }
     }
-  }, [handleCut, handleAuto, handleFtb, dskState, send, sortedSources, cut, setPvw, pgmInput, pgmPip, afvRampUpMs, afvRampDownMs, pips, handleSelectPvw, handleSelectPvwPip])
+  }, [handleCut, handleAuto, handleFtb, dskState, send, sortedSources, cut, pgmInput, pgmPip, afvRampUpMs, afvRampDownMs, pips, handleSelectPvw, handleSelectPvwPip])
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown)
@@ -938,7 +953,7 @@ export function ControllerPage() {
                 <div className="flex flex-col flex-1 gap-2 overflow-y-auto min-h-0">
                   <TransitionPanel onCut={handleCut} onAuto={handleAuto} onFtb={handleFtb} onSelectPvw={handleSelectPvw} onSetOvl={handleSetOvl} onSelectPvwPip={handleSelectPvwPip} pips={pips} pgmPip={pgmPip} pvwPip={pvwPip} className="flex-1" visibleTransitions={controllerOptions.visibleTransitions} />
                   <DskPanel onToggle={handleDskToggle} />
-                  {false && activeProductionId && (
+                  {MACROS_ENABLED && activeProductionId && (
                     <MacroBar productionId={activeProductionId!} onExec={handleMacroExec} />
                   )}
                 </div>

--- a/src/pages/PanePage/index.tsx
+++ b/src/pages/PanePage/index.tsx
@@ -260,7 +260,7 @@ export function PanePage() {
   ]
 
   const [selectedPgmUrl, setSelectedPgmUrl] = useState<string | undefined>(undefined)
-  const [selectedMvUrl, setSelectedMvUrl] = useState<string | undefined>(undefined)
+  const [selectedMvUrl] = useState<string | undefined>(undefined)
   const { audioTrackCount } = useViewerStore()
   const [mvAudioOn, setMvAudioOn] = useState(false)
   const [mvAudioTrack, setMvAudioTrack] = useState(1)
@@ -306,7 +306,9 @@ export function PanePage() {
           if (vt.length > 0) return vt
         }
       }
-    } catch {}
+    } catch {
+      // intentionally empty — malformed/inaccessible localStorage falls back to defaults
+    }
     return [...DEFAULT_TRANSITIONS]
   })
 
@@ -538,7 +540,11 @@ export function PanePage() {
                   onChange={() => {
                     const next = checked ? visibleTransitions.filter((x) => x !== t) : [...visibleTransitions, t]
                     setVisibleTransitions(next)
-                    try { localStorage.setItem(CONTROLLER_OPTIONS_KEY, JSON.stringify({ visibleTransitions: next })) } catch {}
+                    try {
+                      localStorage.setItem(CONTROLLER_OPTIONS_KEY, JSON.stringify({ visibleTransitions: next }))
+                    } catch {
+                      // intentionally empty — best-effort persistence; ignore quota/availability errors
+                    }
                   }}
                   className="accent-orange-500"
                 />

--- a/src/pages/SetupPage/GraphicsPanel.tsx
+++ b/src/pages/SetupPage/GraphicsPanel.tsx
@@ -102,7 +102,7 @@ export function GraphicsPanel() {
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={(e) => { e.stopPropagation(); !inActiveProduction && setEditTarget({ id: g.id, name: g.name, url: g.url }) }}
+                onClick={(e) => { e.stopPropagation(); if (!inActiveProduction) setEditTarget({ id: g.id, name: g.name, url: g.url }) }}
                 disabled={inActiveProduction}
                 className="text-white hover:text-orange-500 disabled:opacity-30 disabled:cursor-not-allowed"
                 title={inActiveProduction ? 'Cannot edit graphic in an active production' : 'Edit graphic'}

--- a/src/pages/SetupPage/OutputsPanel.tsx
+++ b/src/pages/SetupPage/OutputsPanel.tsx
@@ -135,7 +135,7 @@ export function OutputsPanel() {
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={(e) => { e.stopPropagation(); !inActiveProd && setEditTarget({ id: o.id, name: o.name, url: o.url ?? '' }) }}
+                onClick={(e) => { e.stopPropagation(); if (!inActiveProd) setEditTarget({ id: o.id, name: o.name, url: o.url ?? '' }) }}
                 disabled={inActiveProd}
                 className="text-white hover:text-orange-500 disabled:opacity-30 disabled:cursor-not-allowed"
                 title={inActiveProd ? 'Cannot edit output in an active production' : 'Edit output'}

--- a/src/pages/SetupPage/ProductionsPanel.tsx
+++ b/src/pages/SetupPage/ProductionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { getProgramMode } from '@/store/programClock.store'
 import { Link, useNavigate } from 'react-router'
 import { useProductionsStore, type Production } from '@/store/productions.store'
@@ -13,7 +13,7 @@ import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { Modal } from '@/components/ui/Modal'
 import { Tooltip } from '@/components/ui/Tooltip'
-import { selectCls, inputCls, InfoTip, ConfigFieldGroup, PROP_TOOLTIPS } from '@/components/ui/ProductionConfigFields'
+import { selectCls, inputCls, InfoTip, ConfigFieldGroup } from '@/components/ui/ProductionConfigFields'
 
 // ---------------------------------------------------------------------------
 // Stream type labels — used for grouping source dropdowns
@@ -101,7 +101,6 @@ function SlotRow({ index: _index, currentSourceId, canRemove, onChange, onRemove
 // ---------------------------------------------------------------------------
 
 const DSK_SLOTS = ['dsk_in_0', 'dsk_in_1'] as const
-const DSK_LABELS: Record<string, string> = { dsk_in_0: 'DSK 1', dsk_in_1: 'DSK 2' }
 
 interface GfxSlotRowProps {
   dskInput: string
@@ -147,13 +146,12 @@ const OUTPUT_TYPE_LABELS: Record<string, string> = {
 interface OutputSlotRowProps {
   value: string
   usedIds: string[]
-  takenByOtherIds: string[]
   canRemove: boolean
   onChange: (id: string) => void
   onRemove: () => void
 }
 
-function OutputSlotRow({ value, usedIds, takenByOtherIds, canRemove, onChange, onRemove }: OutputSlotRowProps) {
+function OutputSlotRow({ value, usedIds, canRemove, onChange, onRemove }: OutputSlotRowProps) {
   const outputs = useOutputsStore((s) => s.outputs)
   return (
     <div className="flex items-center gap-2">
@@ -207,16 +205,10 @@ interface OptionsModalProps {
 
 function ProductionOptionsModal({ production, onClose }: OptionsModalProps) {
   const { assignSource, unassignSource, assignGraphic, unassignGraphic, updateValues, updateName, assignOutput, unassignOutput } = useProductionsStore()
-  const allProductions = useProductionsStore((s) => s.productions)
   const sources = useSourcesStore((s) => s.sources)
   const graphics = useGraphicsStore((s) => s.graphics)
   const catalogueOutputs = useOutputsStore((s) => s.outputs)
   const isActive = production.status === 'active'
-
-  // Output IDs already assigned to other productions (so we can hide them from this production's dropdowns)
-  const outputsTakenByOthers = allProductions
-    .filter((p) => p.id !== production.id)
-    .flatMap((p) => p.outputAssignments.map((a) => a.outputId))
 
 
   const [outputList, setOutputList] = useState<string[]>(() =>
@@ -372,8 +364,6 @@ function ProductionOptionsModal({ production, onClose }: OptionsModalProps) {
     if (cfg) { setConfigValues({ ...cfg.values }); setValuesDirty(true) }
   }
 
-  const assigned = Object.values(assignments).filter(Boolean).length
-
   const tProps = PRODUCTION_PROPERTIES
   const cfgOnChange = isActive ? undefined : handleValueChange
 
@@ -487,7 +477,7 @@ function ProductionOptionsModal({ production, onClose }: OptionsModalProps) {
               ) : (
                 <div className="flex flex-col gap-2">
                   {outputList.map((id, i) => (
-                    <OutputSlotRow key={i} value={id} usedIds={outputList} takenByOtherIds={[]} canRemove={true} onChange={(newId) => void handleOutputChange(i, newId)} onRemove={() => void handleOutputRemove(i)} />
+                    <OutputSlotRow key={i} value={id} usedIds={outputList} canRemove={true} onChange={(newId) => void handleOutputChange(i, newId)} onRemove={() => void handleOutputRemove(i)} />
                   ))}
                   {outputList.length < MAX_OUTPUTS && (
                     <button type="button" onClick={() => setOutputList((prev) => [...prev, ''])} className="text-xs text-[--color-accent] hover:opacity-80 text-left transition-opacity">+ New Output</button>
@@ -550,11 +540,7 @@ function defaultConfigValues(properties: TemplateProperty[]): Record<string, str
 
 function CreateProductionModal({ onClose, onCreated }: CreateModalProps) {
   const { fetchAll } = useProductionsStore()
-  const allProductions = useProductionsStore((s) => s.productions)
   const sources = useSourcesStore((s) => s.sources)
-
-  // All outputs already assigned to any existing production
-  const outputsTakenByAll = allProductions.flatMap((p) => p.outputAssignments.map((a) => a.outputId))
 
   const [name, setName] = useState('')
   const [assignments, setAssignments] = useState<Record<string, string>>({})
@@ -623,8 +609,6 @@ function CreateProductionModal({ onClose, onCreated }: CreateModalProps) {
       setSaving(false)
     }
   }
-
-  const assignedCount = Object.values(assignments).filter(Boolean).length
 
   const tProps = PRODUCTION_PROPERTIES
 
@@ -717,7 +701,7 @@ function CreateProductionModal({ onClose, onCreated }: CreateModalProps) {
               </div>
               <div className="flex flex-col gap-2">
                 {outputList.map((id, i) => (
-                  <OutputSlotRow key={i} value={id} usedIds={outputList} takenByOtherIds={[]} canRemove={true} onChange={(newId) => setOutputList((prev) => prev.map((v, j) => j === i ? newId : v))} onRemove={() => setOutputList((prev) => prev.filter((_, j) => j !== i))} />
+                  <OutputSlotRow key={i} value={id} usedIds={outputList} canRemove={true} onChange={(newId) => setOutputList((prev) => prev.map((v, j) => j === i ? newId : v))} onRemove={() => setOutputList((prev) => prev.filter((_, j) => j !== i))} />
                 ))}
                 <button type="button" onClick={() => setOutputList((prev) => [...prev, ''])} className="text-xs text-[--color-accent] hover:opacity-80 text-left transition-opacity">+ New Output</button>
               </div>
@@ -1171,61 +1155,6 @@ function InlineCopyButton({ label, value, displayUrl }: { label: string; value: 
       )}
       <span className="uppercase tracking-wide">{label}</span>
     </button>
-  )
-}
-
-function EndpointRow({ label, url }: { label: string; url: string }) {
-  const [copied, setCopied] = useState(false)
-  function handleCopy() {
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    })
-  }
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-[--color-surface-raised] text-[--color-text-muted] uppercase shrink-0">
-        {label}
-      </span>
-      <span className="text-xs font-mono text-[--color-text-primary] truncate flex-1">{url}</span>
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="text-xs text-[--color-text-muted] hover:text-orange-500 transition-colors shrink-0"
-        title={`Copy ${label} URI`}
-      >
-        {copied ? '✓' : '⎘'}
-      </button>
-    </div>
-  )
-}
-
-function WhipEndpointRow({ mixerInput, url }: { mixerInput: string; url: string }) {
-  const [copied, setCopied] = useState(false)
-
-  function handleCopy() {
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    })
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-[--color-surface-raised] text-[--color-text-muted] uppercase shrink-0">
-        WHIP
-      </span>
-      <span className="text-xs font-mono text-[--color-text-muted] shrink-0">{mixerInput}</span>
-      <span className="text-xs font-mono text-[--color-text-primary] truncate flex-1">{url}</span>
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="text-xs text-[--color-text-muted] hover:text-orange-500 transition-colors shrink-0"
-        title="Copy WHIP endpoint URL"
-      >
-        {copied ? '✓' : '⎘'}
-      </button>
-    </div>
   )
 }
 

--- a/src/pages/SetupPage/SourcesPanel.tsx
+++ b/src/pages/SetupPage/SourcesPanel.tsx
@@ -165,7 +165,7 @@ export function SourcesPanel() {
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={(e) => { e.stopPropagation(); !inActiveProduction && setEditTarget({ id: src.id, name: src.name, address: src.address ?? '', latency: src.latency != null ? String(src.latency) : '', streamType: src.streamType }) }}
+                onClick={(e) => { e.stopPropagation(); if (!inActiveProduction) setEditTarget({ id: src.id, name: src.name, address: src.address ?? '', latency: src.latency != null ? String(src.latency) : '', streamType: src.streamType }) }}
                 disabled={inActiveProduction}
                 className="text-white hover:text-orange-500 disabled:opacity-30 disabled:cursor-not-allowed"
                 title={inActiveProduction ? 'Cannot edit source in an active production' : 'Edit source'}

--- a/src/store/productions.store.ts
+++ b/src/store/productions.store.ts
@@ -138,6 +138,7 @@ export const useProductionsStore = create<ProductionsState & ProductionsActions>
           const deadline = Date.now() + ACTIVATION_POLL_TIMEOUT_MS
           const poll = async (): Promise<void> => {
             if (Date.now() >= deadline) {
+              // eslint-disable-next-line no-console -- surfaces activation polling timeout for diagnostics
               console.warn(`[productions] Activation polling timed out for production ${id}`)
               return
             }
@@ -160,6 +161,7 @@ export const useProductionsStore = create<ProductionsState & ProductionsActions>
                 await poll()
               }
             } catch (err) {
+              // eslint-disable-next-line no-console -- surfaces activation poll errors for diagnostics
               console.error(`[productions] Activation poll error for ${id}:`, err)
               // Wait before retrying to prevent burst-recursion on instant-failing errors
               await new Promise<void>((resolve) => setTimeout(resolve, ACTIVATION_POLL_ERROR_DELAY_MS))

--- a/src/store/sources.store.ts
+++ b/src/store/sources.store.ts
@@ -82,7 +82,9 @@ export const useSourcesStore = create<SourcesState & SourcesActions>()(
       },
 
       addSource: async (source) => {
-        const { color: _color, ...apiBody } = source
+        // Strip the client-only `color` field before sending to the API.
+        const { color, ...apiBody } = source
+        void color
         const created = await sourcesApi.create(apiBody)
         set((state) => { state.sources.push(fromApi(created)) })
       },


### PR DESCRIPTION
## Findings (part of Eyevinn/open-live#194)

The required `build-and-lint` check (added in #93, running `eslint src --max-warnings=0`) was actually triggering correctly on every PR here — unlike `open-live`, this repo's trigger config isn't the problem. The real bug: `main` HEAD itself already had **39 lint errors and 14 warnings**, so `build-and-lint` failed unconditionally on every run, including on `main` itself. Since the base branch can't pass its own required check, **no PR could ever merge**, regardless of trigger config, code quality, or review status.

## What this PR does

Fixes every reported error/warning without changing runtime behavior:

- **`no-console`** — kept legitimate `console.error`/`console.warn` diagnostics (ErrorBoundary, `lib/sat.ts`, `lib/webrtc.ts`, `lib/whep.ts`, `main.tsx`, `productions.store.ts`), each with a targeted `eslint-disable-next-line` and a one-line reason, rather than deleting them.
- **`@typescript-eslint/no-unused-vars`** — removed genuinely dead imports/vars/components (confirmed unused elsewhere in the codebase): `isOnOsc`, `CROP_CANVAS_W`, `PipZone`, `COUNTDOWN_WINDOW_MS`, `MAX_RETRIES`/`retryAttempt`/`videoMuted`, `DSK_LABELS`, `EndpointRow`/`WhipEndpointRow`, and dead output-filtering state (`outputsTakenByOthers`, `outputsTakenByAll`, `assigned`, `assignedCount`) plus the never-read `takenByOtherIds` prop in `ProductionsPanel.tsx` (always called with `[]`, never read inside the component). Prefixed one genuinely-unused arg with `_` (`AudioPanel.tsx`).
- **`no-empty`** — added explanatory comments to `catch {}` blocks that intentionally swallow localStorage errors, instead of silently deleting them.
- **`no-constant-binary-expression`** — `ControllerPage/index.tsx` had `{false && activeProductionId && <MacroBar .../>}`. Git history confirms this is a deliberate feature flag (Macros panel hidden, implementation preserved). Replaced the bare `false` literal with a named `MACROS_ENABLED = false` constant — behavior unchanged, rule satisfied.
- **`@typescript-eslint/no-unused-expressions`** — rewrote `cond && setEditTarget(...)` click handlers as `if (cond) setEditTarget(...)`.
- **`react-hooks/exhaustive-deps`** — kept intentional omissions (depending on primitive `source` fields, not the object reference, to avoid reconnect storms) with a targeted disable + explanation; removed genuinely unnecessary deps elsewhere; fixed `PgmPreview.tsx`'s cleanup-closure ref capture per the rule's own recommended pattern.

`pnpm run lint`, `pnpm run typecheck`, and `pnpm run build` all pass cleanly with zero errors/warnings.

Also adds `workflow_dispatch` to `ci.yml` (same rationale as [Eyevinn/open-live#195](https://github.com/Eyevinn/open-live/pull/195)) so CI can be manually re-run against a branch without an empty commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)