### PR TITLE
ci: fix concurrency-group deadlock in sync-fork-on-merge.yml

### DIFF
--- a/.github/workflows/sync-fork-on-merge.yml
+++ b/.github/workflows/sync-fork-on-merge.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: sync-fork-prod
+  group: sync-fork-on-merge-prod
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Same root cause as [Eyevinn/open-live#196](https://github.com/Eyevinn/open-live/pull/196): this repo has the identical `sync-fork-on-merge.yml` + `sync-fork.yml` pair, so it hits the same concurrency-group self-deadlock on every merge into `main` — `sync-fork-on-merge.yml`'s top-level group (`sync-fork-prod`) collides with `sync-fork.yml`'s job-level group (`sync-fork-${{ inputs.environment }}` → `sync-fork-prod` for `environment: prod`), and GitHub cancels it as a deadlock every time.

Renamed this workflow's group to `sync-fork-on-merge-prod` to match the open-live fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)