### PR TITLE
fix(studio): wire nginx.conf.template into Docker image for full security headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,25 +20,9 @@ RUN rm -rf /usr/share/nginx/html/*
 # Copy built SPA
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx config — serve index.html for all routes (SPA fallback)
-COPY <<'EOF' /etc/nginx/conf.d/default.conf.template
-server {
-    listen %PORT%;
-    root /usr/share/nginx/html;
-    index index.html;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; connect-src %CSP_CONNECT_SRC%; media-src 'self' blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    location = /env-config.js {
-        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
-    }
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-EOF
+# nginx config — full security-header suite + SPA fallback (see nginx.conf.template).
+# The template uses the %PORT% placeholder, substituted at container start by the CMD below.
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

The production `Dockerfile` baked a **sparse inline nginx config** via a `COPY <<'EOF'` heredoc instead of using the repository's canonical `nginx.conf.template` (the resolution of #32). As a result, Docker deployments served a config that did not fully match the maintained template — in particular the template's per-location repetition of security headers for `/env-config.js` (nginx does not inherit server-level `add_header` into a `location` that defines its own `add_header`) and the maintained CSP were never applied in the built image.

This wires the real template into the image so Docker deployments serve the full security-header suite (CSP, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `X-Frame-Options`, and `Cache-Control: no-store` for `/env-config.js`, which contains `OSC_PAT`).

## Changes

- Replaced the inline heredoc nginx config in `Dockerfile` with `COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template`.
- Kept the existing `%PORT%` placeholder substitution flow (the container `CMD` runs `sed s/%PORT%/$PORT/ ...`), which matches the template's `%PORT%` delimiter. No change to base image (`nginx:1.27-alpine`), `EXPOSE 8080`, `ENV PORT=8080`, or `docker-entrypoint.sh`.

## Test Plan

- [x] `pnpm install --frozen-lockfile` — success
- [x] `pnpm run lint` — pass (exit 0)
- [x] `pnpm run typecheck` — pass (exit 0)
- [x] `pnpm run build` — success (only pre-existing chunk-size / dynamic-import warnings)
- [ ] `docker build` — **NOT run: docker is not available in the agent environment.** Verified the `%PORT%` substitution logic manually (`sed s/%PORT%/8080/ nginx.conf.template` produces `listen 8080;`). Running-container header verification was not performed.

This change only touches the `Dockerfile` (not app source), so lint/typecheck/build are unaffected; they were run to confirm no regression.

Closes #39

🤖 Generated with Claude Code