### PR TITLE
fix(infra): narrow CSP connect-src to prevent exfiltration to arbitrary hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self' wss:; media-src 'self' blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src %CSP_CONNECT_SRC%; media-src 'self' blob:; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     location = /env-config.js {
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
@@ -47,5 +47,7 @@ ENV PORT=8080
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
+# docker-entrypoint.sh renders default.conf from the template (substituting
+# %PORT% and %CSP_CONNECT_SRC%) before exec'ing this CMD.
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["/bin/sh", "-c", "sed s/%PORT%/$PORT/ /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,4 +32,28 @@ else
     > /usr/share/nginx/html/env-config.js
 fi
 
+# Render the nginx config from the template, tightening the CSP connect-src so
+# the SPA can only reach the origins it actually talks to:
+#   - 'self'                              static assets + /env-config.js
+#   - $OPEN_LIVE_URL (https)              open-live REST API
+#   - wss/ws origin of $OPEN_LIVE_URL     open-live controller WebSocket
+#                                         (src derives ws(s) from the same origin)
+#   - https://token.svc.prod.osaas.io     OSC SAT token exchange (hardcoded in src/lib/sat.ts)
+# When OPEN_LIVE_URL is unset we cannot know the exact backend host, so we fall
+# back to the OSC deployment origins rather than a bare wss:/https: wildcard.
+PORT="${PORT:-8080}"
+TOKEN_ORIGIN="https://token.svc.prod.osaas.io"
+if [ -n "$OPEN_LIVE_URL" ]; then
+  # Derive the WebSocket scheme/origin from the backend URL (https->wss, http->ws),
+  # mirroring src/lib/base.ts + useControllerWs.ts (BASE.replace(/^http/, 'ws')).
+  BACKEND_WS="$(printf '%s' "$OPEN_LIVE_URL" | sed -e 's|^https://|wss://|' -e 's|^http://|ws://|')"
+  CSP_CONNECT_SRC="'self' $OPEN_LIVE_URL $BACKEND_WS $TOKEN_ORIGIN"
+else
+  CSP_CONNECT_SRC="'self' wss://*.osaas.io https://*.osaas.io"
+fi
+
+sed -e "s|%PORT%|$PORT|g" \
+    -e "s|%CSP_CONNECT_SRC%|$CSP_CONNECT_SRC|g" \
+  /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
 exec "$@"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -6,7 +6,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
 
     # nginx does not inherit server-level add_header in location blocks
     # that define their own add_header, so repeat security headers here.
@@ -16,7 +16,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' wss: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+        add_header Content-Security-Policy "default-src 'none'; connect-src %CSP_CONNECT_SRC%; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
Closes #40.

The Content-Security-Policy served by nginx used a bare `connect-src 'self' wss: https:` wildcard. Those wildcards let any script on the page open WebSocket/fetch connections to any TLS host, so if XSS were ever achieved (e.g. a future dependency CVE) an attacker could exfiltrate the SAT token or production state to an arbitrary server (OWASP A05). This narrows `connect-src` to only the origins the studio actually talks to.

The studio's real connect destinations (verified in source):
- `'self'` — static assets and `/env-config.js`
- `OPEN_LIVE_URL` (https) — open-live REST API (`src/lib/base.ts`, `src/lib/api.ts`)
- the `ws://`/`wss://` origin of `OPEN_LIVE_URL` — controller WebSocket (`src/hooks/useControllerWs.ts` derives it via `BASE.replace(/^http/, 'ws')`)
- `https://token.svc.prod.osaas.io` — OSC SAT token exchange (hardcoded in `src/lib/sat.ts`)

Since the backend origin is a runtime variable, the tightened value is generated at container start from `OPEN_LIVE_URL` in `docker-entrypoint.sh` and substituted into the nginx template via a `%CSP_CONNECT_SRC%` placeholder (same mechanism already used for `%PORT%`).

## Changes
- `nginx.conf.template`: replace bare `connect-src 'self' wss: https:` with `%CSP_CONNECT_SRC%` placeholder (server block + `/env-config.js` location).
- `Dockerfile`: replace the inline `default.conf.template`'s bare `connect-src 'self' wss:` with `%CSP_CONNECT_SRC%`; move the `%PORT%`/CSP templating out of `CMD` (now just runs nginx) since the entrypoint renders the config. All other security headers (media-src, blob:, Permissions-Policy, frame-ancestors) are left intact.
- `docker-entrypoint.sh`: derive `CSP_CONNECT_SRC` from `OPEN_LIVE_URL` (backend https origin + its ws/wss origin + the OSC token service), then `sed`-substitute `%PORT%` and `%CSP_CONNECT_SRC%` into the config. When `OPEN_LIVE_URL` is unset it falls back to `'self' wss://*.osaas.io https://*.osaas.io` — narrowed to OSC deployments rather than a bare wildcard.

Resulting connect-src on OSC, e.g. for `OPEN_LIVE_URL=https://x.eyevinn.osaas.io`:
`'self' https://x.eyevinn.osaas.io wss://x.eyevinn.osaas.io https://token.svc.prod.osaas.io`

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run lint` — zero warnings/errors
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — succeeds
- [x] `sh -n docker-entrypoint.sh` — POSIX sh syntax OK
- [x] Simulated entrypoint rendering for OSC (https), local dev (http→ws), and unset `OPEN_LIVE_URL` cases — all produce a non-wildcard (or narrowed `*.osaas.io`) connect-src with no leftover placeholders
- [ ] Reviewer: confirm legitimate wss backend + https token-service connections still succeed against a live OSC deployment

## Checklist
- [x] Branched from `main`
- [x] All existing security headers preserved
- [x] No fabricated hosts — every origin verified against the source
- [x] No secrets committed

🤖 Generated with Claude Code