### PR TITLE
fix(studio): add X-Robots-Tag noindex to env-config.js

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -14,6 +14,7 @@ server {
     location = /env-config.js {
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         add_header Pragma "no-cache" always;
+        add_header X-Robots-Tag "noindex, nofollow" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary

Adds `add_header X-Robots-Tag "noindex, nofollow" always;` to the `location = /env-config.js` block in `nginx.conf.template`. This instructs search engines not to index or follow the publicly served `env-config.js` file. The existing `Cache-Control: no-store, no-cache, must-revalidate` + `Pragma: no-cache` headers were already present; `X-Robots-Tag` was the one missing header from the security report's short-term mitigation.

## Scope / important caveat

This is a **partial mitigation for #10 (defense-in-depth), NOT a full fix.** The frontend genuinely consumes `OSC_PAT` from `window._env_` at runtime (`src/lib/sat.ts` exchanges it for a short-lived SAT), so the PAT cannot be removed from the served bundle without breaking auth. The real resolution — moving the PAT→SAT exchange server-side so the long-lived PAT never reaches the browser — is a cross-service backend change tracked separately as an epic. This PR only reduces incidental exposure (search-engine indexing) and intentionally does not close #10.

## Test plan

- [x] `pnpm install --frozen-lockfile` — succeeded
- [x] `pnpm run build` — succeeded (only pre-existing chunk-size warnings)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] Post-deploy: `curl -I https://<host>/env-config.js` and confirm `X-Robots-Tag: noindex, nofollow` is present alongside the existing cache/security headers

Note: this repo has no test suite; the change is nginx-config only.